### PR TITLE
fix: Build type resource path from `method_name`

### DIFF
--- a/src/unzer/client.py
+++ b/src/unzer/client.py
@@ -330,7 +330,7 @@ class UnzerClient:
             raise TypeError("Expected a PaymentType object. Got %r" % type(paymentType))
         paymentType.validateBeforeRequest()
         data = self.request(
-            "types/%s" % paymentType.method,
+            "types/%s" % paymentType.method_name.value,
             "POST",
             paymentType.serialize(),
         )


### PR DESCRIPTION
## Summary

`createPaymentType()` interpolated the `PaymentTypes` enum member itself instead of a name,
so every server-side type creation requested a non-existent path:

```python
"types/%s" % paymentType.method   # -> types/PaymentTypes.CARD
```

Two things were wrong at once: stringifying the enum member yields `PaymentTypes.CARD`
rather than a value, and `method` holds the short code used in type ids (`crd`) while the
types endpoint expects the full method name (`card`).

```
before: POST /v1/types/PaymentTypes.CARD
after:  POST /v1/types/card
```

## Motivation

The bug stayed invisible as long as payment types were created on the client side (Payment
Page, UI components), which hands a ready `typeId` to the backend. It surfaces as soon as a
type has to be created server-side — which is mandatory for Installment and Direct Bank
Transfer.

## Verification

`"types/%s" % Card.method_name.value` yields `types/card`. For every payment type the
resulting path was checked against the API reference (`api.unzer.com/swagger-ui/api-docs`);
all of them exist there. Not yet run against the sandbox API with a real keypair.
