### PR TITLE
fix: Ten bugs found by testing against the API

### DIFF
--- a/src/unzer/client.py
+++ b/src/unzer/client.py
@@ -5,7 +5,6 @@ from types import NoneType
 from urllib.parse import urlencode
 
 import requests
-from urllib3.exceptions import TimeoutError
 
 from . import __version__
 from .model import *
@@ -30,7 +29,21 @@ class UnzerClient:
     """Default API version, used unless a request asks for another one."""
 
     retryDelays = (1, 2, 4, 8)
-    """Delays in seconds between the retries of a failed request."""
+    """Delays in seconds between the retries of a failed request.
+
+    Only applies to the methods in :attr:`retryableMethods`.
+    """
+
+    retryableMethods = ("GET", "HEAD")
+    """HTTP methods that may be retried after a timeout or a server error.
+
+    Deliberately excludes POST, PUT and DELETE. A timed out POST may well have been
+    carried out by the API with only the response getting lost, so repeating it can
+    charge a customer twice -- and the Unzer API offers no idempotency key to guard
+    against that (there is none in either of its OpenAPI specs). A failed write is
+    therefore raised to the caller, who can look the payment up by ``orderId`` and
+    decide.
+    """
 
     timeout = 30
     """Timeout in seconds of a single request.
@@ -55,7 +68,14 @@ class UnzerClient:
 
         :param private_key: The private key of the keypair.
         :param public_key: The public key of the keypair.
-        :param sandbox: (optional) Use the sandbox environment.
+        :param sandbox: (optional) Mark this client as working on a sandbox account.
+
+            This does **not** change the endpoint: whether a request hits the
+            sandbox or production is decided by the key alone (``s-`` versus ``p-``
+            prefix), and ``api.unzer.com`` serves both. The flag is kept because
+            consumers need to know which mode they are in -- among other things the
+            redirect URLs Unzer returns differ (``sbx-payment.unzer.com`` versus
+            ``payment.unzer.com``).
         :param language: (optional) Language for translations of customer messages.
         :param client_ip: (optional) IP address of the customer.
             Sent as ``CLIENTIP`` header with every request.
@@ -135,7 +155,9 @@ class UnzerClient:
             or after last retry failed.
         """
         r = None
-        for idx, delay in enumerate((0,) + self.retryDelays):
+        retryable = method.upper() in self.retryableMethods
+        delays = (0,) + (self.retryDelays if retryable else ())
+        for idx, delay in enumerate(delays):
             logger.debug("Perform try no. %d (delay: %d)", idx, delay)
             time.sleep(delay)
             logger.debug("%s %s", method, url)
@@ -151,8 +173,11 @@ class UnzerClient:
                     verify=True,
                     timeout=self.timeout,
                 )
-            except (TimeoutError, requests.exceptions.ReadTimeout):
-                logger.exception("Caught TimeoutError")
+            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+                # Timeout covers both ConnectTimeout and ReadTimeout.
+                logger.exception("Request failed on the transport level")
+                if not retryable:
+                    raise
                 continue
             if 200 <= r.status_code <= 201:
                 logger.debug("Response[%s %s]: %r", r.status_code, r.reason, r.json())
@@ -160,6 +185,8 @@ class UnzerClient:
             elif 500 <= r.status_code < 600:
                 logger.debug("Server error")
                 logger.debug("Response[%s %s]: %r", r.status_code, r.reason, r.text)
+                if not retryable:
+                    break
                 continue
             else:
                 logger.debug("Client error")
@@ -494,7 +521,7 @@ class UnzerClient:
             raise TypeError("Expected a PaymentPage object. Got %r" % type(paymentPage))
         paymentPage.validateBeforeRequest()
         data = self.request(
-            "paypage/%s" % paymentPage.action,
+            f"paypage/{paymentPage.action.value}",
             "POST",
             paymentPage.serialize(),
         )
@@ -687,7 +714,7 @@ class UnzerClient:
             webhooks = [data]  # got exactly one webhook, data is the webhook itself
         else:
             webhooks = data["events"]  # list of webhooks wrapped in events property
-        return map(Webhook.fromDict, webhooks)
+        return [Webhook.fromDict(webhook) for webhook in webhooks]
 
     def deleteWebhook(self, webhookOrId):
         """Delete a specific webhook.

--- a/src/unzer/model/additional_transaction_data.py
+++ b/src/unzer/model/additional_transaction_data.py
@@ -81,12 +81,26 @@ class ShippingTransactionData(BaseModel):
 
 
 class CustomerGroup(enum.StrEnum):
+    """Risk classification of a customer.
+
+    .. seealso:: https://github.com/unzerdev/php-sdk/blob/main/src/Constants/CustomerGroups.php
+    """
+
     TOP = "TOP"
     GOOD = "GOOD"
     NEUTRAL = "NEUTRAL"
 
 
 class RegistrationLevel(enum.IntEnum):
+    """Whether the customer has an account with the merchant.
+
+    The source declares these as the strings ``"0"`` and ``"1"``; an
+    :class:`enum.IntEnum` is used here because the API accepts both and the
+    numbers read better at the call site.
+
+    .. seealso:: https://github.com/unzerdev/php-sdk/blob/main/src/Constants/CustomerRegistrationLevel.php
+    """
+
     GUEST = 0
     REGISTERED = 1
 

--- a/src/unzer/model/basket.py
+++ b/src/unzer/model/basket.py
@@ -2,7 +2,7 @@ import typing as t
 
 from .base import BaseModel, JSONValue
 from .basketItem import BasketItem
-from ..utils import parseFloat
+from ..utils import parseFloat, roundAmount
 
 
 class Basket(BaseModel):
@@ -89,12 +89,12 @@ class Basket(BaseModel):
             "basketItems": [bi.serialize() for bi in self.basketItems],
         }
         if self.isV3():
-            data["totalValueGross"] = self.totalValueGross
+            data["totalValueGross"] = roundAmount(self.totalValueGross)
         else:
             data |= {
-                "amountTotalGross": self.amountTotalGross,
-                "amountTotalVat": self.amountTotalVat,
-                "amountTotalDiscount": self.amountTotalDiscount,
+                "amountTotalGross": roundAmount(self.amountTotalGross),
+                "amountTotalVat": roundAmount(self.amountTotalVat),
+                "amountTotalDiscount": roundAmount(self.amountTotalDiscount),
             }
         return data
 

--- a/src/unzer/model/customer.py
+++ b/src/unzer/model/customer.py
@@ -138,19 +138,22 @@ class Customer(BaseModel):
         if isinstance(birthDate, (datetime.datetime, datetime.date)):
             birthDate = birthDate.strftime("%Y-%m-%d")
 
-        billingAddress = self.billingAddress
-        if billingAddress is None:
-            billingAddress = self.EMPTY_STRING
-        else:
-            assert isinstance(billingAddress, Address)
-            billingAddress = billingAddress.serialize()
-
-        shippingAddress = self.shippingAddress
-        if shippingAddress is None:
-            shippingAddress = self.EMPTY_STRING
-        else:
-            assert isinstance(shippingAddress, Address)
-            shippingAddress = shippingAddress.serialize()
+        # An empty string is rejected by the API with API.410.300.007
+        # ("HTTP message not readable") because the field is an object, not a
+        # string. null is accepted, so missing addresses are sent as None.
+        addresses = {}
+        for name in ("billingAddress", "shippingAddress"):
+            address = getattr(self, name)
+            if address is None:
+                addresses[name] = None
+            elif isinstance(address, Address):
+                addresses[name] = address.serialize()
+            else:
+                raise TypeError(
+                    f"Expected an Address object for {name}. Got {type(address)!r}"
+                )
+        billingAddress = addresses["billingAddress"]
+        shippingAddress = addresses["shippingAddress"]
 
         return {
             "lastname": self.lastname,

--- a/src/unzer/model/customer.py
+++ b/src/unzer/model/customer.py
@@ -5,6 +5,14 @@ from .base import BaseModel
 
 
 class Salutation:
+    """Salutation of a customer.
+
+    ``unknown`` is a real value here, not a placeholder: it is what the API answers
+    for a customer whose salutation is not known.
+
+    .. seealso:: https://github.com/unzerdev/php-sdk/blob/main/src/Constants/Salutations.php
+    """
+
     MR = "mr"
     MRS = "mrs"
     UNKNOWN = "unknown"

--- a/src/unzer/model/installment_plans.py
+++ b/src/unzer/model/installment_plans.py
@@ -2,7 +2,7 @@ import datetime
 import typing as t
 
 from .base import BaseModel, JSONValue
-from ..utils import parseBool, parseDate, parseFloat
+from ..utils import parseBool, parseDate, parseFloat, parseTimestamp
 
 
 class InstallmentRate(BaseModel):
@@ -151,11 +151,9 @@ class InstallmentPlans(BaseModel):
         data = data.copy()
         data["inquiryId"] = data["id"]
         data["amount"] = parseFloat(data.get("amount"))
-        # Unzer sends the expiry as unix timestamp (as string)
-        if data.get("expiresAt"):
-            data["expiresAt"] = datetime.datetime.fromtimestamp(int(data["expiresAt"]))
-        else:
-            data["expiresAt"] = None
+        # Unzer sends the expiry as unix timestamp (as string), in milliseconds --
+        # the API reference shows seconds. parseTimestamp handles both.
+        data["expiresAt"] = parseTimestamp(data.get("expiresAt"))
         data["plans"] = [InstallmentPlan.fromDict(plan) for plan in data.get("plans") or []]
         for key in ("isSuccess", "isPending", "isResumed", "isError"):
             data[key] = parseBool(data[key]) if key in data else None

--- a/src/unzer/model/payment.py
+++ b/src/unzer/model/payment.py
@@ -16,6 +16,11 @@ logger = logging.getLogger("unzer-sdk").getChild(__name__)
 
 
 class TransactionStatus(enum.Enum):
+    """Status of a single transaction inside a payment.
+
+    .. seealso:: https://github.com/unzerdev/php-sdk/blob/main/src/Constants/TransactionStatus.php
+    """
+
     SUCCESS = "success"
     PENDING = "pending"
     ERROR = "error"
@@ -25,11 +30,12 @@ class TransactionStatus(enum.Enum):
 class Action(enum.Enum):
     """Transaction type of a transaction inside a payment.
 
-    Mirrors ``TransactionTypes`` of the PHP SDK. Note that a payment lists every
-    transaction it has, so anything but ``authorize`` and ``charge`` shows up here
-    as soon as a payment was cancelled, shipped or paid out -- even though this SDK
-    cannot yet create those. Keep this complete: a missing member makes
-    :meth:`UnzerClient.getPayment` raise for the whole payment.
+    Note that a payment lists every transaction it has, so anything but ``authorize``
+    and ``charge`` shows up here as soon as a payment was cancelled, shipped or paid
+    out -- even though this SDK cannot yet create those. Keep this complete: a
+    missing member makes :meth:`UnzerClient.getPayment` raise for the whole payment.
+
+    .. seealso:: https://github.com/unzerdev/php-sdk/blob/main/src/Constants/TransactionTypes.php
     """
 
     AUTHORIZE = "authorize"
@@ -40,9 +46,15 @@ class Action(enum.Enum):
     SHIPMENT = "shipment"
     PAYOUT = "payout"
     CHARGEBACK = "chargeback"
+    SCA = "strong_customer_authentication"
 
 
 class PaymentState(enum.Enum):
+    """Overall state of a payment.
+
+    .. seealso:: https://github.com/unzerdev/php-sdk/blob/main/src/Constants/PaymentState.php
+    """
+
     PENDING = 0
     COMPLETED = 1
     CANCELED = 2
@@ -58,7 +70,14 @@ class PaymentTypes(enum.Enum):
 
     Used as short-name in type-ids like ``s-crd-abc456def789``
 
-    source: https://github.com/unzerdev/java-sdk/blob/main/src/main/java/com/unzer/payment/paymenttypes/PaymentTypeEnum.java  # noqa: E501
+    .. seealso:: https://github.com/unzerdev/java-sdk/blob/main/src/main/java/com/unzer/payment/paymenttypes/PaymentTypeEnum.java  # noqa: E501
+
+    .. note::
+        The source has one member this enum deliberately does not:
+        ``UNKNOWN("unknown")``, which the Java SDK uses as a parsing fallback
+        (``.orElse(PaymentTypeEnum.UNKNOWN)``). Here an unrecognised short code
+        raises instead -- it means this SDK is behind the API, and a placeholder
+        would hide that. See :meth:`PaymentGetResponse.getPaymentTypeFromTypeId`.
     """
     CARD = "crd"
     CLICK_TO_PAY = "ctp"
@@ -102,7 +121,7 @@ class PaymentMethodTypes(enum.Enum):
 
     Used as name in URLs like ``types/<name>/``
 
-    source: https://github.com/unzerdev/integration-core/blob/master/src/BusinessLogic/Domain/PaymentMethod/Enums/PaymentMethodTypes.php  # noqa: E501
+    .. seealso:: https://github.com/unzerdev/integration-core/blob/master/src/BusinessLogic/Domain/PaymentMethod/Enums/PaymentMethodTypes.php  # noqa: E501
     """
     ALI_PAY = "alipay"
     APPLE_PAY = "applepay"

--- a/src/unzer/model/payment.py
+++ b/src/unzer/model/payment.py
@@ -7,21 +7,39 @@ from types import NoneType
 
 from .additional_transaction_data import AdditionalTransactionData
 from .base import BaseModel
-from ..utils import parseBool, parseDateTime
+from ..utils import parseBool, parseDateTime, roundAmount
 
 if t.TYPE_CHECKING:
     from ..client import UnzerClient
+
+logger = logging.getLogger("unzer-sdk").getChild(__name__)
 
 
 class TransactionStatus(enum.Enum):
     SUCCESS = "success"
     PENDING = "pending"
     ERROR = "error"
+    RESUMED = "resumed"
 
 
 class Action(enum.Enum):
-    CHARGE = "charge"
+    """Transaction type of a transaction inside a payment.
+
+    Mirrors ``TransactionTypes`` of the PHP SDK. Note that a payment lists every
+    transaction it has, so anything but ``authorize`` and ``charge`` shows up here
+    as soon as a payment was cancelled, shipped or paid out -- even though this SDK
+    cannot yet create those. Keep this complete: a missing member makes
+    :meth:`UnzerClient.getPayment` raise for the whole payment.
+    """
+
     AUTHORIZE = "authorize"
+    PREAUTHORIZE = "preauthorize"
+    CHARGE = "charge"
+    REVERSAL = "cancel-authorize"
+    REFUND = "cancel-charge"
+    SHIPMENT = "shipment"
+    PAYOUT = "payout"
+    CHARGEBACK = "chargeback"
 
 
 class PaymentState(enum.Enum):
@@ -76,7 +94,6 @@ class PaymentTypes(enum.Enum):
     TWINT = "twt"
     OPEN_BANKING = "obp"
     WERO = "wro"
-    UNKNOWN = "unknown"
 
 
 class PaymentMethodTypes(enum.Enum):
@@ -117,10 +134,14 @@ class PaymentMethodTypes(enum.Enum):
 # TODO: Combine PaymentMethodTypes and PaymentTypes in a dataclass to have their mapping too?
 
 paymentUrlRe = re.compile(
-    r"^https://api.unzer.com/v1/"
+    # Host and version are not pinned: the endpoint is configurable, and some
+    # resources answer on a newer version than the one that was requested.
+    r"^https://[\w.-]+/v\d+/"
     r"(?P<operation>[a-z]+)/(?P<paymentId>[\w-]+)"  # payments/{codeOrOrderId}
-    r"((/(?P<subOperation>[a-z]+)/(?P<subCode>[\w-]+))?"  # /[charges|authorize|shipments|payouts]/{txnCode|chargeCode}
-    r"(/(?P<subSubOperation>[a-z]+)/(?P<subSubCode>[\w-]+))?)?"  # /chargebacks/{chargeBackCode} | /cancels/{cancelCode}
+    # /[charges|authorize|shipments|payouts]/{txnCode|chargeCode}
+    r"((/(?P<subOperation>[a-z-]+)/(?P<subCode>[\w-]+))?"
+    # /chargebacks/{code} | /cancels/{code} | /due-date-extensions/{code}
+    r"(/(?P<subSubOperation>[a-z-]+)/(?P<subSubCode>[\w-]+))?)?"
 )
 
 
@@ -263,15 +284,30 @@ class PaymentGetResponse(BaseModel):
         return transactions
 
     @staticmethod
-    def getPaymentTypeFromTypeId(typeId) -> PaymentTypes:
+    def getPaymentTypeFromTypeId(typeId: str) -> PaymentTypes:
+        """Derive the payment type from a type id such as ``s-crd-abc456def789``.
+
+        A type id is built from the environment, the short code and a random part.
+        An id this SDK cannot read raises: a placeholder return value would only
+        move the problem into the caller, and ``unknown`` is a real value in this
+        API elsewhere (see :class:`~unzer.model.customer.Salutation`), so it could
+        not be told apart from one.
+
+        :param typeId: The id of a payment type resource.
+        :raises ValueError: If the id is malformed or names an unknown type.
+        """
         if not typeId:
-            raise ValueError("Invalid typeId %r" % typeId)  # TODO: or return PaymentTypes.UNKNOWN?
-        paymentType = typeId.split("-")[1].lower()
+            raise ValueError(f"Invalid typeId {typeId!r}")
+        parts = typeId.split("-")
+        if len(parts) < 3:
+            raise ValueError(f"Invalid typeId {typeId!r}: expected the form s-crd-xxx")
         try:
-            paymentType = PaymentTypes(paymentType)
+            return PaymentTypes(parts[1].lower())
         except ValueError:
-            raise ValueError("Invalid type %r" % typeId)  # TODO: or return PaymentTypes.UNKNOWN?
-        return paymentType
+            raise ValueError(
+                f"Unknown payment type {parts[1]!r} in typeId {typeId!r}. If Unzer "
+                f"added a type, it has to be added to PaymentTypes."
+            ) from None
 
     def charge(self, amount: float) -> "PaymentResponse":
         req_kwargs = self.__dict__.copy()
@@ -303,7 +339,6 @@ class PaymentTransaction(BaseModel):
         :type participantId: str
         :param date: (optional)
         :type date: datetime.datetime
-        :param String:
         :param action: (optional)
         :type action: Action
         :param status: (optional)
@@ -329,19 +364,26 @@ class PaymentTransaction(BaseModel):
     @classmethod
     def fromDict(cls, data):
         data = data.copy()
-        data["status"] = data["status"].lower()  # must be equivalent to enum *TransactionStatus*
-        data["action"] = data["type"].lower()  # must be equivalent to enum *Action*
+        # A value the enums do not know means this SDK is behind the API, which is a
+        # defect worth seeing. It raises rather than degrading into a placeholder.
+        data["status"] = TransactionStatus(data["status"].lower())
+        data["action"] = Action(data["type"].lower())
         data["date"] = parseDateTime(data["date"])
         data["amount"] = float(data["amount"])
         # And now some ugly parsing of the url, because Unzer provide no suitable parameters
         # url-example: https://api.unzer.com/v1/payments/s-pay-123456/charges/s-chg-1
         # url-example: https://api.unzer.com/v1/payments/s-pay-123456/charges/s-chg-1/cancels/s-cnl-1
-        assert data["url"], data["url"]
+        if not data.get("url"):
+            raise ValueError("Transaction has no url to derive its ids from")
         match = re.match(paymentUrlRe, data["url"])
-        assert match, "Cannot match %r" % data["url"]
+        if not match:
+            raise ValueError(f"Cannot parse transaction url {data['url']!r}")
         matchDict = match.groupdict()
-        logging.debug("matchDict: %r for url %r", matchDict, data["url"])
-        assert matchDict["operation"] == "payments", "Operation %r not matching" % matchDict["operation"]
+        logger.debug(f"matchDict: {matchDict!r} for url {data['url']!r}")
+        if matchDict["operation"] != "payments":
+            raise ValueError(
+                f"Unexpected operation {matchDict['operation']!r} in transaction url"
+            )
         data["paymentId"] = matchDict["paymentId"]
         data["subOperation"] = matchDict["subOperation"]
         data["subCode"] = data["transactionId"] = matchDict["subCode"]
@@ -430,7 +472,7 @@ class PaymentRequest(BaseModel):
 
     def serialize(self):
         data = {
-            "amount": self.amount,
+            "amount": roundAmount(self.amount),
             "currency": self.currency,
             "returnUrl": self.returnUrl,
             "card3ds": self.card3ds,

--- a/src/unzer/model/payment.py
+++ b/src/unzer/model/payment.py
@@ -72,12 +72,27 @@ class PaymentTypes(enum.Enum):
 
     .. seealso:: https://github.com/unzerdev/java-sdk/blob/main/src/main/java/com/unzer/payment/paymenttypes/PaymentTypeEnum.java  # noqa: E501
 
-    .. note::
-        The source has one member this enum deliberately does not:
-        ``UNKNOWN("unknown")``, which the Java SDK uses as a parsing fallback
-        (``.orElse(PaymentTypeEnum.UNKNOWN)``). Here an unrecognised short code
-        raises instead -- it means this SDK is behind the API, and a placeholder
-        would hide that. See :meth:`PaymentGetResponse.getPaymentTypeFromTypeId`.
+    The official SDKs disagree on the exact set, so both were compared. Three
+    deliberate differences:
+
+    ``UNKNOWN("unknown")``
+        Exists in the Java SDK, which uses it as a parsing fallback
+        (``.orElse(PaymentTypeEnum.UNKNOWN)``), and not in the PHP SDK
+        (``Constants/IdStrings.php``). Left out here: an unrecognised short code
+        means this SDK is behind the API, and a placeholder would hide that.
+        See :meth:`PaymentGetResponse.getPaymentTypeFromTypeId`.
+
+    ``ppg`` (payment page)
+        The PHP SDK counts the payment page among the payment types. It is a
+        resource of its own here, and the API never puts a ``s-ppg-`` id into
+        ``resources.typeId`` -- it belongs to ``resources.payPageId``, verified
+        against the sandbox. See :class:`unzer.model.PaymentPage`.
+
+    ``ctp`` (Click to Pay)
+        Present here, and a constant but not a payment type in the PHP SDK.
+        The method is live -- sandbox accounts have it enabled.
+
+    .. seealso:: https://github.com/unzerdev/php-sdk/blob/main/src/Constants/IdStrings.php
     """
     CARD = "crd"
     CLICK_TO_PAY = "ctp"

--- a/src/unzer/model/payment_type/abstract_paymenttype.py
+++ b/src/unzer/model/payment_type/abstract_paymenttype.py
@@ -1,4 +1,5 @@
 import abc
+import enum
 import logging
 import typing as t
 
@@ -8,6 +9,25 @@ if t.TYPE_CHECKING:
     from ..payment import PaymentTypes, PaymentMethodTypes  # noqa
 
 logger = logging.getLogger("unzer-sdk").getChild(__name__)
+
+
+class _UnknownMethodName:
+    """Stand-in for the URL slug of a payment type the SDK does not know.
+
+    Accessing :attr:`value` raises instead of handing a useless string to the
+    request builder, so the error names the actual problem.
+    """
+
+    @property
+    def value(self) -> str:
+        raise NotImplementedError(
+            "This payment type has no implementation in this SDK, so its resource "
+            "path is unknown. It can be used to read existing payments, but not to "
+            "create a new payment type."
+        )
+
+    def __repr__(self) -> str:
+        return "<unknown method name>"
 
 
 class PaymentType(BaseModel):
@@ -47,7 +67,7 @@ class PaymentType(BaseModel):
         return cls(**data)
 
     @classmethod
-    def get_subclasses(cls) -> t.Type[t.Self]:
+    def get_subclasses(cls) -> t.Iterator[type[t.Self]]:
         for subclass in cls.__subclasses__():
             yield from subclass.get_subclasses()
             yield subclass
@@ -58,24 +78,97 @@ class PaymentType(BaseModel):
             if subclass.method == method:
                 return subclass
         logger.warning(f"Creating not existing PaymentType for method {method} on the fly")
-        sub_cls = type(str(method).title(), (cls,), {"method": method, "method_name": "N/A"})
+        short = (method.name.title().replace("_", "")
+                 if isinstance(method, enum.Enum) else str(method).title())
+        name = f"{short}PaymentType"
+        # method_name must stay an enum member: the client reads `.value` off it to
+        # build the resource path. There is no slug for an unknown type, so the
+        # placeholder raises on use instead of failing with an AttributeError.
+        sub_cls = type(name, (cls,), {"method": method, "method_name": _UnknownMethodName()})
         return sub_cls  # noqa
 
     def get_configuration(self) -> dict:
         if self._client is None:
             raise IOError(f"PaymentType {type(self).__name__} was not initialized with client instance")
+        configurations = self.get_configurations()
+        if len(configurations) > 1:
+            logger.warning(
+                f"Keypair holds {len(configurations)} configurations for "
+                f"{self.method_name}, using the first one"
+            )
+        return configurations[0]
+
+    def get_configurations(self) -> list[dict]:
+        """Provide every keypair configuration for this payment type.
+
+        A keypair can hold more than one entry per payment type -- observed with
+        ``card``, where two entries differ in their supported brands and channel.
+        :meth:`get_configuration` returns only the first one, so use this method
+        when the distinction matters.
+
+        :raises LookupError: If the payment type is not configured at all.
+        """
+        if self._client is None:
+            raise IOError(f"PaymentType {type(self).__name__} was not initialized with client instance")
         key_pair_types = self._client.getKeyPairTypes()
-        logger.debug(f"key_pair_types: {key_pair_types}")
-        for payment_type in key_pair_types["paymentTypes"]:
-            # Compared case-insensitive: Unzer is not consistent about the casing
-            # of the method names (e.g. EPS is documented as *EPS* and as *eps*)
-            if payment_type["type"].lower() == self.method_name.value.lower():
-                return payment_type
-        raise LookupError(f"PaymentType {self.method_name} is not configured in the keypair")
+        logger.debug(f"key_pair_types: {key_pair_types!r}")
+        # Compared case-insensitive: Unzer is not consistent about the casing of the
+        # method names -- the API really does answer with *EPS* while the resource
+        # path is *eps*.
+        wanted = self.method_name.value.lower()
+        configurations = [
+            payment_type
+            for payment_type in key_pair_types["paymentTypes"]
+            if payment_type["type"].lower() == wanted
+        ]
+        if not configurations:
+            raise LookupError(f"PaymentType {self.method_name} is not configured in the keypair")
+        return configurations
 
     # TODO: Without caching this isn't the best solution --> better implement in the KeyPairTypeModel
-    def get_channel_id(self) -> str:
-        return self.get_configuration()["supports"][0]["channel"]
+    def get_channel_id(self, brand: str | None = None) -> str:
+        """Provide the channel id configured for this payment type.
 
-    def get_brands(self) -> list[str]:
-        return self.get_configuration()["supports"][0]["brands"]
+        :param brand: (optional) Restrict the lookup to the configuration that
+            supports this brand (e.g. ``AMEX``). Required whenever a keypair holds
+            several configurations for one payment type -- a real keypair was seen
+            with two ``card`` entries, one for ``MASTER``/``VISA`` and one for
+            ``AMEX``, each on its own channel. Without the brand the first entry
+            wins, which is the wrong channel for every other brand.
+        :raises LookupError: If no configuration supports the requested brand.
+        """
+        return self._support(brand)["channel"]
+
+    def get_brands(self, brand: str | None = None) -> list[str]:
+        """Provide the card brands this payment type accepts.
+
+        :param brand: (optional) See :meth:`get_channel_id`.
+        """
+        return self._support(brand)["brands"]
+
+    def _support(self, brand: str | None = None) -> dict:
+        """Pick the ``supports`` entry to read channel and brands from."""
+        configurations = self.get_configurations()
+        supports = [
+            support
+            for configuration in configurations
+            for support in configuration.get("supports") or []
+        ]
+        if brand is not None:
+            matching = [s for s in supports if brand.upper() in
+                        {str(b).upper() for b in s.get("brands") or []}]
+            if not matching:
+                available = sorted({b for s in supports for b in s.get("brands") or []})
+                raise LookupError(
+                    f"No configuration of {self.method_name} supports the brand "
+                    f"{brand!r}. Available: {available}"
+                )
+            supports = matching
+        if not supports:
+            raise LookupError(f"PaymentType {self.method_name} has no supports entry")
+        if len(supports) > 1:
+            logger.warning(
+                f"{self.method_name} has {len(supports)} configurations; using the "
+                f"first one. Pass brand= to choose."
+            )
+        return supports[0]

--- a/src/unzer/model/paymentpage.py
+++ b/src/unzer/model/paymentpage.py
@@ -1,6 +1,8 @@
+from types import NoneType
+
 from .base import BaseModel
 from .payment import Action
-from ..utils import parseBool
+from ..utils import parseBool, roundAmount
 
 
 class PaymentPage(BaseModel):
@@ -41,7 +43,8 @@ class PaymentPage(BaseModel):
         """Create a new PaymentPage.
 
         Payment attributes:
-        :param action: (required) Action for this paypage. Charge or authorize.
+        :param action: (required) Action for this paypage: charge or authorize.
+            Accepts the enum member or its name in any casing.
         :type action: str | Action
         :param amount: (required) The transaction amount.
         :type amount: float
@@ -99,10 +102,20 @@ class PaymentPage(BaseModel):
             additionalAttributes = {}
         if css is None:
             css = {}
-        if action not in {Action.CHARGE, Action.AUTHORIZE}:
-            raise TypeError("Invalid action %r" % action)
-        if not isinstance(card3ds, bool):
-            raise TypeError("Invalid value %r for card3ds. Must be a boolean." % card3ds)
+        # The API answers with the upper case name ("CHARGE"), while the request
+        # path needs the lower case value ("charge"), so accept both spellings
+        # and keep the enum member internally.
+        if isinstance(action, str):
+            try:
+                action = Action(action.lower())
+            except ValueError:
+                raise TypeError(f"Invalid action {action!r}") from None
+        elif not isinstance(action, Action):
+            raise TypeError(f"Invalid action {action!r}")
+        if not isinstance(card3ds, (bool, NoneType)):
+            raise TypeError(
+                f"Invalid value {card3ds!r} for card3ds. Must be a boolean or None."
+            )
         self.amount = amount  # type:float
         self.currency = currency  # type:str
         self.returnUrl = returnUrl  # type:str
@@ -122,14 +135,14 @@ class PaymentPage(BaseModel):
         self.card3ds = card3ds  # type:bool
         self.additionalAttributes = additionalAttributes  # type:dict[str, str]
         self.excludeTypes = excludeTypes  # type:list[str]
-        self.action = action  # type:str
+        self.action = action  # type:Action
         self.customerId = customerId  # type:str
         self.metadataId = metadataId  # type:str
         self.basketId = basketId  # type:str
 
     def serialize(self):
         data = {
-            "amount": self.amount,
+            "amount": roundAmount(self.amount),
             "currency": self.currency,
             "invoiceId": self.invoiceId,
             "orderId": self.orderId,
@@ -212,5 +225,5 @@ class PaymentPageResponse(PaymentPage):
         data["card3ds"] = parseBool(data["card3ds"])
         data["shippingAddressRequired"] = parseBool(data["shippingAddressRequired"])
         data["billingAddressRequired"] = parseBool(data["billingAddressRequired"])
-        data["action"] = data["action"].lower()  # must be equivalent to enum *Action*
+        # action is converted to the Action enum by __init__
         return cls(**data)

--- a/src/unzer/model/webhook.py
+++ b/src/unzer/model/webhook.py
@@ -1,3 +1,5 @@
+import enum
+
 from .base import BaseModel
 
 # https://docs.unzer.com/reference/basic-integration-req/#allowlist-of-ip-addresses
@@ -9,20 +11,36 @@ IP_ADDRESS = {
 }
 
 
-class Events:
+class Events(enum.StrEnum):
+    """Webhook event names.
+
+    Mirrors ``WebhookEvents`` of the PHP SDK. Being a :class:`enum.StrEnum`, the
+    members compare equal to their string value, so ``event="charge.succeeded"``
+    keeps working.
+    """
+
     ALL = "all"
     AUTHORIZE = "authorize"
     AUTHORIZE_SUCCEEDED = "authorize.succeeded"
     AUTHORIZE_FAILED = "authorize.failed"
-    AUTHORIZE_PENDING = "authorize.pendin"
+    AUTHORIZE_PENDING = "authorize.pending"
     AUTHORIZE_EXPIRED = "authorize.expired"
     AUTHORIZE_CANCELED = "authorize.canceled"
+    AUTHORIZE_RESUMED = "authorize.resumed"
+    PREAUTHORIZE = "preauthorize"
+    PREAUTHORIZE_SUCCEEDED = "preauthorize.succeeded"
+    PREAUTHORIZE_FAILED = "preauthorize.failed"
+    PREAUTHORIZE_PENDING = "preauthorize.pending"
+    PREAUTHORIZE_EXPIRED = "preauthorize.expired"
+    PREAUTHORIZE_CANCELED = "preauthorize.canceled"
+    PREAUTHORIZE_RESUMED = "preauthorize.resumed"
     CHARGE = "charge"
     CHARGE_SUCCEEDED = "charge.succeeded"
     CHARGE_FAILED = "charge.failed"
-    CHARGE_PENDING = "charge.pendin"
+    CHARGE_PENDING = "charge.pending"
     CHARGE_EXPIRED = "charge.expired"
     CHARGE_CANCELED = "charge.canceled"
+    CHARGE_RESUMED = "charge.resumed"
     CHARGEBACK = "chargeback"
     TYPES = "types"
     CUSTOMER = "customer"
@@ -83,10 +101,13 @@ class Webhook(BaseModel):
             value = [value]
         if not isinstance(value, list):
             raise TypeError("Event must be a str or list of str. Got %r" % type(value))
+        events = []
         for val in value:
-            if val not in vars(Events).values():
-                raise TypeError("Invalid value %r for event" % value)
-        self._event = value
+            try:
+                events.append(Events(val))
+            except ValueError:
+                raise TypeError(f"Invalid value {val!r} for event") from None
+        self._event = events
 
     def serialize(self):
         return {

--- a/src/unzer/model/webhook.py
+++ b/src/unzer/model/webhook.py
@@ -14,9 +14,10 @@ IP_ADDRESS = {
 class Events(enum.StrEnum):
     """Webhook event names.
 
-    Mirrors ``WebhookEvents`` of the PHP SDK. Being a :class:`enum.StrEnum`, the
-    members compare equal to their string value, so ``event="charge.succeeded"``
-    keeps working.
+    Being a :class:`enum.StrEnum`, the members compare equal to their string value,
+    so ``event="charge.succeeded"`` keeps working.
+
+    .. seealso:: https://github.com/unzerdev/php-sdk/blob/main/src/Constants/WebhookEvents.php
     """
 
     ALL = "all"

--- a/src/unzer/utils.py
+++ b/src/unzer/utils.py
@@ -33,3 +33,42 @@ def parseFloat(value):
     if value is None or value == "":
         return None
     return float(value)
+
+
+def roundAmount(value: float | int | str | None) -> float | None:
+    """Round a monetary amount to the four decimal places the API accepts.
+
+    The API specifies amounts as ``Decimal{10,4}``. Two things go wrong without
+    this. Floating point arithmetic produces residues -- ``12.3 - 10.0 - 2.3`` is
+    ``8.88e-16``, not ``0`` -- and :func:`json.dumps` writes those in scientific
+    notation, which is not a number the API accepts. And an amount carrying more
+    than four decimals is silently truncated on their side.
+
+    :param value: The amount, or ``None``.
+    :return: The rounded amount, or ``None`` if there was none.
+    """
+    if value is None or value == "":
+        return None
+    return round(float(value), 4)
+
+
+def parseTimestamp(value: str | int | float | None) -> datetime.datetime | None:
+    """Parse a unix timestamp that may be in seconds or in milliseconds.
+
+    The API reference gives ``expiresAt`` as ``1735689599`` -- ten digits, seconds.
+    The API actually answers with thirteen digits, milliseconds. Reading that as
+    seconds lands in the year 58608 and raises, which made
+    :meth:`UnzerClient.getPaylaterInstallmentPlans` unusable.
+
+    Rather than picking one unit, the magnitude decides: anything past the year
+    5138 in seconds is milliseconds.
+
+    :param value: The timestamp, as string or number.
+    :return: The parsed datetime, or ``None`` if there was no value.
+    """
+    if value is None or value == "":
+        return None
+    timestamp = float(value)
+    if abs(timestamp) > 1e11:
+        timestamp /= 1000
+    return datetime.datetime.fromtimestamp(timestamp)

--- a/tests/sandbox/test_live_api.py
+++ b/tests/sandbox/test_live_api.py
@@ -1,0 +1,291 @@
+"""Tests against the real Unzer sandbox.
+
+Skipped unless ``UNZER_PRIVATE_KEY`` holds a sandbox key -- see ``tests/conftest.py``.
+
+These exist because mocks can only confirm what we believed when we wrote them, and
+Unzer's documentation and SDKs are wrong often enough that belief is not enough. Every
+assertion here has caught, or could catch, a difference between the documentation and
+the running API.
+
+**What cannot be tested here.** Several payment types are created client-side, by the
+Payment Page or the UI components: the browser collects the data and only the resulting
+``typeId`` reaches the backend. Creating such a type server-side yields an empty
+resource that the payment provider then rejects -- an attempt with Klarna returns
+``COR.800.400.160 "Validation error at partner system"``, which looks like an SDK bug
+but is not one. Affected: Card, Klarna, PayPal, Apple Pay, Google Pay, iDEAL,
+Click to Pay. Only types whose fields the SDK actually sends are exercised below.
+
+**Sandbox accounts differ** in which methods they have enabled, so each test checks
+``keypair/types`` first and skips what the account cannot do.
+"""
+
+import uuid
+
+import pytest
+
+from unzer.model import (
+    Action,
+    Address,
+    Basket,
+    BasketItem,
+    Customer,
+    ErrorResponse,
+    PaymentPage,
+    PaymentRequest,
+    SepaDirectDebit,
+)
+
+pytestmark = pytest.mark.sandbox
+
+# Official sandbox test data: docs.unzer.com/reference/test-data/
+TEST_IBAN = "DE89370400440532013000"
+TEST_BIC = "COBADEFFXXX"
+TEST_HOLDER = "Maximilian Mustermann"
+
+
+@pytest.fixture(scope="module")
+def enabled_methods(sandbox_client):
+    """The payment method slugs this account has enabled, lower cased.
+
+    Unzer is inconsistent about the casing -- the API answers ``EPS`` while the
+    resource path is ``eps``.
+    """
+    types = sandbox_client.getKeyPairTypes()["paymentTypes"]
+    return {entry["type"].lower() for entry in types}
+
+
+def requires(sandbox_client, enabled_methods, slug):
+    if slug not in enabled_methods:
+        pytest.skip(f"account has no {slug}; enabled: {sorted(enabled_methods)}")
+
+
+class TestKeypair:
+
+    def test_keypair_is_readable(self, sandbox_client):
+        assert sandbox_client.getKeyPair()["publicKey"].startswith("s-pub-")
+
+    def test_sandbox_key_reaches_the_default_endpoint(self, sandbox_client):
+        """`sandbox=True` does not switch hosts: the key prefix decides the
+        environment and api.unzer.com serves both."""
+        assert sandbox_client.endpoint == "https://api.unzer.com"
+        assert sandbox_client.getKeyPair()["publicKey"]
+
+    def test_keypair_types_may_repeat_a_payment_type(self, sandbox_client):
+        """Documented as one entry per type; some accounts return several."""
+        types = [entry["type"] for entry in sandbox_client.getKeyPairTypes()["paymentTypes"]]
+        assert types, "account has no payment types at all"
+        # Not an assertion about duplicates -- just that reading them never crashes.
+        assert all(isinstance(name, str) for name in types)
+
+    def test_every_configuration_is_reachable(self, sandbox_client, enabled_methods):
+        """On an account that configures one type twice, both must be readable.
+
+        Seen with `card`: MASTER/VISA on one channel, AMEX on another. Reading only
+        the first entry hands out the wrong channel for the other brands.
+        """
+        entries = sandbox_client.getKeyPairTypes()["paymentTypes"]
+        names = [entry["type"].lower() for entry in entries]
+        repeated = {name for name in names if names.count(name) > 1}
+        if not repeated:
+            pytest.skip(f"account configures every type once: {sorted(set(names))}")
+        for name in repeated:
+            configurations = [e for e in entries if e["type"].lower() == name]
+            channels = {s["channel"] for c in configurations for s in c["supports"]}
+            assert len(channels) == len(configurations), \
+                f"{name} has {len(configurations)} configurations but {len(channels)} channels"
+
+    def test_channel_can_be_picked_by_brand(self, sandbox_client, enabled_methods):
+        requires(sandbox_client, enabled_methods, "card")
+        from unzer.model import Card
+        card = Card(client=sandbox_client)
+        brands = {
+            brand
+            for configuration in card.get_configurations()
+            for support in configuration.get("supports") or []
+            for brand in support.get("brands") or []
+        }
+        if not brands:
+            pytest.skip("card configuration lists no brands")
+        for brand in sorted(brands):
+            assert card.get_channel_id(brand=brand), f"no channel for {brand}"
+        # On an account with two card entries the channels must actually differ.
+        channels = {card.get_channel_id(brand=b) for b in brands}
+        assert len(channels) >= 1
+
+    def test_unknown_brand_raises_lookup_error(self, sandbox_client, enabled_methods):
+        requires(sandbox_client, enabled_methods, "card")
+        from unzer.model import Card
+        with pytest.raises(LookupError):
+            Card(client=sandbox_client).get_channel_id(brand="NOT-A-BRAND")
+
+    def test_customer_types_is_a_comma_separated_string(self, sandbox_client):
+        """Not a list -- `B2B,B2C` arrives as one string."""
+        for entry in sandbox_client.getKeyPairTypes()["paymentTypes"]:
+            allowed = entry.get("allowCustomerTypes")
+            if allowed is None:
+                continue
+            assert isinstance(allowed, str), f"{entry['type']}: {type(allowed)}"
+            assert set(allowed.split(",")) <= {"B2B", "B2C"}, allowed
+
+
+class TestCustomer:
+
+    def test_customer_without_addresses_is_accepted(self, sandbox_client):
+        """Sending "" for a missing address returns HTTP 400 API.410.300.007."""
+        customer = sandbox_client.createCustomer(
+            Customer(firstname="Maximilian", lastname="Mustermann",
+                     email="maximilian.mustermann@example.com")
+        )
+        assert customer.key.startswith("s-cst-")
+        # The API answers with an empty address object, never with a string.
+        assert isinstance(customer.billingAddress, Address)
+
+    def test_customer_with_addresses_round_trips(self, sandbox_client):
+        address = Address(firstname="Maximilian", lastname="Mustermann",
+                          street="Hugo-Junkers-Str. 3", zipCode="60386",
+                          city="Frankfurt am Main", country="DE")
+        customer = sandbox_client.createCustomer(
+            Customer(firstname="Maximilian", lastname="Mustermann", salutation="mr",
+                     birthDate="1980-11-22", email="maximilian.mustermann@example.com",
+                     billingAddress=address)
+        )
+        assert customer.billingAddress.city == "Frankfurt am Main"
+        assert customer.billingAddress.zipCode == "60386"
+
+    def test_empty_state_is_accepted(self, sandbox_client):
+        """The docs list state as required for a billing address; it is not."""
+        address = Address(firstname="Maximilian", lastname="Mustermann",
+                          street="Hugo-Junkers-Str. 3", zipCode="60386",
+                          city="Frankfurt am Main", country="DE", state=None)
+        customer = sandbox_client.createCustomer(
+            Customer(firstname="Maximilian", lastname="Mustermann", billingAddress=address)
+        )
+        assert customer.key
+
+    def test_create_or_update_recovers_from_a_duplicate(self, sandbox_client):
+        """The second call must not fail on the duplicate customerId.
+
+        A fresh id per run on purpose: a fixed one would make the test depend on
+        what an earlier run left behind in the sandbox.
+        """
+        customer_id = f"sdk-test-{uuid.uuid4().hex[:12]}"
+        first = sandbox_client.createOrUpdateCustomer(
+            Customer(firstname="Maximilian", lastname="Mustermann", customerId=customer_id))
+        assert first.customerId == customer_id
+        assert first.firstname == "Maximilian"
+
+        # Same customerId, different data: createCustomer answers 400 and the
+        # client is expected to fall back to updateCustomer.
+        second = sandbox_client.createOrUpdateCustomer(
+            Customer(firstname="Maximiliane", lastname="Mustermann", customerId=customer_id))
+        assert second.key == first.key, "the update must not create a second resource"
+
+        # Read it back separately. The customer returned by updateCustomer comes from
+        # a GET issued immediately after the PUT, which has been seen to still carry
+        # the previous name -- so the write is verified, not that response.
+        assert sandbox_client.getCustomer(customer_id).firstname == "Maximiliane"
+
+
+class TestBasket:
+
+    def test_v1_basket(self, sandbox_client):
+        basket = sandbox_client.createBasket(Basket(
+            amountTotalGross=100.0, amountTotalVat=15.97, amountTotalDiscount=0,
+            currencyCode="EUR", orderId="sdk-test-basket-v1",
+            basketItems=[BasketItem(
+                title="T-Shirt", quantity=1, vat=19, amountGross=100.0, amountPerUnit=100.0,
+                amountNet=84.03, amountVat=15.97, basketItemReferenceId="item-1", type="goods")],
+        ))
+        assert basket.key
+        assert not basket.isV3()
+
+    def test_v3_basket(self, sandbox_client):
+        basket = sandbox_client.createBasket(Basket(
+            totalValueGross=100.0, currencyCode="EUR", orderId="sdk-test-basket-v3",
+            basketItems=[BasketItem(
+                title="T-Shirt", quantity=1, vat=19, amountPerUnitGross=100.0,
+                basketItemReferenceId="item-1", type="goods")],
+        ))
+        assert basket.key
+        # v3 ids are UUIDs while v1 ids are short counters -- a cheap way to tell
+        # which endpoint actually served the request.
+        assert basket.isV3()
+        assert len(basket.key) > len("s-bsk-999")
+
+
+class TestPaymentPage:
+    """Paypage v1 is tagged [Deprecated] in the spec but still works."""
+
+    def test_create_and_fetch(self, sandbox_client):
+        page = sandbox_client.createPaymentPage(PaymentPage(
+            action=Action.CHARGE, amount=100.0, currency="EUR",
+            returnUrl="https://shop.example.com/return", orderId="sdk-test-paypage",
+        ))
+        assert page.payPageId.startswith("s-ppg-")
+        assert page.action is Action.CHARGE
+        fetched = sandbox_client.getPaymentPage(page.payPageId)
+        assert fetched.payPageId == page.payPageId
+        assert fetched.action is Action.CHARGE
+
+    def test_redirect_url_points_at_the_sandbox(self, sandbox_client):
+        """The host differs between sandbox and production, which is the reason
+        consumers need to know which mode they are in."""
+        page = sandbox_client.createPaymentPage(PaymentPage(
+            action=Action.CHARGE, amount=100.0, currency="EUR",
+            returnUrl="https://shop.example.com/return",
+        ))
+        assert "sbx-" in page.redirectUrl, page.redirectUrl
+
+
+class TestSepaDirectDebit:
+    """SEPA direct debit is created server-side, so it can be exercised here."""
+
+    def test_create_payment_type(self, sandbox_client, enabled_methods):
+        requires(sandbox_client, enabled_methods, "sepa-direct-debit")
+        created = sandbox_client.createPaymentType(
+            SepaDirectDebit(iban=TEST_IBAN, bic=TEST_BIC, holder=TEST_HOLDER))
+        assert created.key.startswith("s-sdd-")
+        assert created.iban == TEST_IBAN
+
+    def test_charge_and_read_back(self, sandbox_client, enabled_methods):
+        requires(sandbox_client, enabled_methods, "sepa-direct-debit")
+        response = sandbox_client.charge(PaymentRequest(
+            paymentType=SepaDirectDebit(iban=TEST_IBAN, bic=TEST_BIC, holder=TEST_HOLDER),
+            amount=12.34, currency="EUR", returnUrl="https://shop.example.com/return",
+            orderId="sdk-test-sdd-charge",
+        ))
+        assert response.isSuccess
+        assert response.transactionId.startswith("s-chg-")
+        assert response.processing.shortId, "processing must carry the short id"
+
+        payment = sandbox_client.getPayment(response.paymentId)
+        assert payment.amountCharged == 12.34
+        charged = payment.getChargedTransactions()
+        assert len(charged) == 1, "getChargedTransactions used to return []"
+        assert charged[0].transactionId == response.transactionId
+
+    def test_transaction_actions_are_enums(self, sandbox_client, enabled_methods):
+        requires(sandbox_client, enabled_methods, "sepa-direct-debit")
+        response = sandbox_client.charge(PaymentRequest(
+            paymentType=SepaDirectDebit(iban=TEST_IBAN, bic=TEST_BIC, holder=TEST_HOLDER),
+            amount=1.0, currency="EUR", returnUrl="https://shop.example.com/return",
+        ))
+        payment = sandbox_client.getPayment(response.paymentId)
+        assert all(isinstance(txn.action, Action) for txn in payment.transactions)
+
+
+class TestErrorShape:
+
+    def test_unknown_payment_raises_error_response(self, sandbox_client):
+        with pytest.raises(ErrorResponse) as excinfo:
+            sandbox_client.getPayment("s-pay-does-not-exist")
+        error = excinfo.value
+        assert error.statusCode >= 400
+        assert error.errors, "the API always sends at least one error entry"
+        assert error.errors[0].code
+        assert error.errors[0].merchantMessage
+
+    def test_error_carries_a_trace_id(self, sandbox_client):
+        with pytest.raises(ErrorResponse) as excinfo:
+            sandbox_client.getPayment("s-pay-does-not-exist")
+        assert excinfo.value.errorId or excinfo.value.traceId

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,197 @@
+"""Tests for the transport layer of :class:`unzer.UnzerClient`."""
+
+import json
+
+import pytest
+import requests
+import responses
+
+from unzer import UnzerClient, __version__
+from unzer.model import ErrorResponse
+
+BASE = "https://api.unzer.com/v1"
+
+
+class TestRequestBuilding:
+    """Headers, authentication and URL construction."""
+
+    @responses.activate
+    def test_uses_private_key_as_basic_auth_username(self, client):
+        responses.add(responses.GET, f"{BASE}/keypair", json={"publicKey": "s-pub-x"})
+        client.getKeyPair()
+        auth = responses.calls[0].request.headers["Authorization"]
+        assert auth.startswith("Basic ")
+
+    @responses.activate
+    def test_sends_user_agent_with_version(self, client):
+        responses.add(responses.GET, f"{BASE}/keypair", json={})
+        client.getKeyPair()
+        assert responses.calls[0].request.headers["user-agent"] == f"unzer-python-sdk {__version__}"
+
+    @responses.activate
+    def test_language_becomes_accept_language(self):
+        client = UnzerClient("s-priv-x", "s-pub-x", language="de")
+        responses.add(responses.GET, f"{BASE}/keypair", json={})
+        client.getKeyPair()
+        assert responses.calls[0].request.headers["accept-language"] == "de"
+
+    @responses.activate
+    def test_client_ip_is_sent_as_clientip_header(self):
+        # The API reference names this header x-CLIENTIP, but the API expects
+        # CLIENTIP -- verified against the sandbox, see AGENTS.md.
+        client = UnzerClient("s-priv-x", "s-pub-x", client_ip="203.0.113.7")
+        responses.add(responses.GET, f"{BASE}/keypair", json={})
+        client.getKeyPair()
+        assert responses.calls[0].request.headers["CLIENTIP"] == "203.0.113.7"
+
+    @responses.activate
+    def test_no_clientip_header_without_client_ip(self, client):
+        responses.add(responses.GET, f"{BASE}/keypair", json={})
+        client.getKeyPair()
+        assert "CLIENTIP" not in responses.calls[0].request.headers
+
+    @responses.activate
+    def test_api_version_can_be_overridden_per_request(self, client):
+        responses.add(responses.GET, "https://api.unzer.com/v3/baskets/s-bsk-1",
+                      json={"id": "s-bsk-1", "basketItems": []})
+        client.getBasket("s-bsk-1", api_version="v3")
+        assert "/v3/baskets/" in responses.calls[0].request.url
+
+    @responses.activate
+    def test_additional_headers_are_merged(self, client):
+        responses.add(responses.GET, f"{BASE}/keypair", json={})
+        client.request("keypair", "GET", additional_headers={"X-Extra": "1"})
+        assert responses.calls[0].request.headers["X-Extra"] == "1"
+
+
+class TestErrorHandling:
+
+    @responses.activate
+    def test_client_error_raises_error_response(self, client, fixture_json):
+        payload = fixture_json("error_400")
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1", json=payload, status=400)
+        with pytest.raises(ErrorResponse) as excinfo:
+            client.getPayment("s-pay-1")
+        error = excinfo.value
+        assert error.statusCode == 400
+        assert error.errorId == payload["id"]
+        assert [e.code for e in error.errors] == ["API.320.200.145"]
+        assert error.errors[0].merchantMessage == "Basket is already in use."
+
+    @responses.activate
+    def test_error_response_keeps_the_source_response(self, client, fixture_json):
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1",
+                      json=fixture_json("error_400"), status=400)
+        with pytest.raises(ErrorResponse) as excinfo:
+            client.getPayment("s-pay-1")
+        assert isinstance(excinfo.value.srcResponse, requests.Response)
+
+    @responses.activate
+    def test_success_status_with_error_flag_raises(self, client, fixture_json):
+        """The API answers 2xx with an error payload -- documented behaviour."""
+        charge = fixture_json("charge") | {"isError": True, "isSuccess": False}
+        charge["errors"] = fixture_json("error_400")["errors"]
+        charge["timestamp"] = "2026-08-21 10:15:32"
+        charge["url"] = f"{BASE}/payments/s-pay-1/charges"
+        responses.add(responses.POST, f"{BASE}/payments/charges", json=charge, status=200)
+        from unzer.model import PaymentRequest, SepaDirectDebit
+        payment_type = SepaDirectDebit(key="s-sdd-1", iban="DE89370400440532013000")
+        with pytest.raises(ErrorResponse):
+            client.charge(PaymentRequest(paymentType=payment_type, amount=1.0))
+
+
+class TestRetryPolicy:
+    """Only idempotent methods may be repeated -- Unzer has no idempotency keys."""
+
+    def test_only_get_and_head_are_retryable(self, client):
+        assert client.retryableMethods == ("GET", "HEAD")
+
+    @responses.activate
+    def test_get_is_retried_on_server_error(self, retrying_client, fixture_json):
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1", status=500)
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1", status=500)
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1", json=fixture_json("payment_get"))
+        payment = retrying_client.getPayment("s-pay-1")
+        assert payment.paymentId == "s-pay-123456"
+        assert len(responses.calls) == 3
+
+    @responses.activate
+    def test_post_is_not_retried_on_server_error(self, retrying_client):
+        """A repeated POST could charge a customer twice."""
+        responses.add(responses.POST, f"{BASE}/customers", status=500)
+        from unzer.model import Customer
+        with pytest.raises(ErrorResponse):
+            retrying_client.createCustomer(Customer(firstname="A", lastname="B"))
+        assert len(responses.calls) == 1, "POST must not be repeated"
+
+    @responses.activate
+    def test_get_is_retried_on_timeout(self, retrying_client, fixture_json):
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1",
+                      body=requests.exceptions.ConnectTimeout())
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1", json=fixture_json("payment_get"))
+        assert retrying_client.getPayment("s-pay-1").paymentId == "s-pay-123456"
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_post_raises_on_timeout_instead_of_retrying(self, retrying_client):
+        responses.add(responses.POST, f"{BASE}/customers",
+                      body=requests.exceptions.ReadTimeout())
+        from unzer.model import Customer
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            retrying_client.createCustomer(Customer(firstname="A", lastname="B"))
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_connection_error_is_retried_for_get(self, retrying_client, fixture_json):
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1",
+                      body=requests.exceptions.ConnectionError())
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1", json=fixture_json("payment_get"))
+        assert retrying_client.getPayment("s-pay-1").paymentId == "s-pay-123456"
+
+
+class TestWebhooks:
+
+    @responses.activate
+    def test_list_webhooks_returns_a_list(self, client, fixture_json):
+        responses.add(responses.GET, f"{BASE}/webhooks", json=fixture_json("webhooks_list"))
+        hooks = client.listWebhooks()
+        assert isinstance(hooks, list), "a map object can only be consumed once"
+        assert len(hooks) == 2
+        assert hooks[0].webhookId == "s-whk-1"
+
+    @responses.activate
+    def test_single_webhook_response_is_wrapped_in_a_list(self, client, fixture_json):
+        responses.add(responses.POST, f"{BASE}/webhooks", json=fixture_json("webhook_single"))
+        from unzer.model import Events, Webhook
+        hooks = client.createWebhook(Webhook(url="https://shop.example.com/webhook",
+                                             event=Events.CHARGE_SUCCEEDED))
+        assert isinstance(hooks, list)
+        assert len(hooks) == 1
+
+    @responses.activate
+    def test_delete_webhook_accepts_a_model(self, client):
+        responses.add(responses.DELETE, f"{BASE}/webhooks/s-whk-1", json={"id": "s-whk-1"})
+        from unzer.model import Webhook
+        webhook = Webhook(url="https://shop.example.com/webhook", webhookId="s-whk-1")
+        assert client.deleteWebhook(webhook) == "s-whk-1"
+
+
+class TestTypeChecks:
+    """The client rejects wrong argument types before spending a request."""
+
+    @pytest.mark.parametrize("method,argument", [
+        ("getError", 1),
+        ("getPayment", 1),
+        ("getPaymentPage", 1),
+        ("createCustomer", "not-a-customer"),
+        ("createBasket", "not-a-basket"),
+        ("createPaymentType", "not-a-payment-type"),
+    ])
+    def test_wrong_type_raises_type_error(self, client, method, argument):
+        with pytest.raises(TypeError):
+            getattr(client, method)(argument)
+
+    def test_create_customer_rejects_customer_with_key(self, client):
+        from unzer.model import Customer
+        with pytest.raises(TypeError, match="Call updateCustomer"):
+            client.createCustomer(Customer(firstname="A", lastname="B", key="s-cst-1"))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,277 @@
+"""Tests for the model layer: serialisation, deserialisation and validation."""
+
+import datetime
+
+import pytest
+
+from unzer.model import (
+    Action,
+    Address,
+    Basket,
+    BasketItem,
+    Customer,
+    Events,
+    PaymentGetResponse,
+    PaymentPage,
+    PaymentPageResponse,
+    PaymentRequest,
+    PaymentState,
+    PaymentType,
+    PaymentTypes,
+    TransactionStatus,
+    Webhook,
+)
+from unzer.model.customer import Salutation
+
+# Every concrete payment type the SDK ships, discovered the same way the client does.
+PAYMENT_TYPE_CLASSES = sorted(set(PaymentType.get_subclasses()), key=lambda c: c.__name__)
+
+
+class TestPaymentTypes:
+
+    def test_sdk_ships_the_expected_number_of_types(self):
+        assert len(PAYMENT_TYPE_CLASSES) == 24
+
+    @pytest.mark.parametrize("cls", PAYMENT_TYPE_CLASSES, ids=lambda c: c.__name__)
+    def test_every_type_declares_method_and_method_name(self, cls):
+        """`method` is the short code (crd), `method_name` the URL slug (card)."""
+        assert isinstance(cls.method, PaymentTypes)
+        assert cls.method_name.value, f"{cls.__name__} has no URL slug"
+
+    @pytest.mark.parametrize("cls", PAYMENT_TYPE_CLASSES, ids=lambda c: c.__name__)
+    def test_from_dict_maps_id_to_key(self, cls):
+        assert cls.fromDict({"id": "s-xxx-1"}).key == "s-xxx-1"
+
+    @pytest.mark.parametrize("cls", PAYMENT_TYPE_CLASSES, ids=lambda c: c.__name__)
+    def test_serialize_returns_a_dict(self, cls):
+        assert isinstance(cls().serialize(), dict)
+
+    def test_method_names_are_unique(self):
+        slugs = [c.method_name.value for c in PAYMENT_TYPE_CLASSES]
+        assert len(slugs) == len(set(slugs)), "two types claim the same URL slug"
+
+    def test_construct_finds_the_class_for_a_short_code(self):
+        assert PaymentType.construct(PaymentTypes.CARD).__name__ == "Card"
+
+    def test_construct_builds_a_placeholder_for_unknown_types(self):
+        cls = PaymentType.construct(PaymentTypes.GIROPAY)
+        assert issubclass(cls, PaymentType)
+        # The placeholder must not hand a bogus slug to the request builder.
+        with pytest.raises(NotImplementedError):
+            cls.method_name.value
+
+
+class TestBasket:
+    """The basket has two incompatible schemas; the amount fields decide which."""
+
+    def test_v1_is_used_without_total_value_gross(self, fixture_json):
+        basket = Basket.fromDict(fixture_json("basket_v1"))
+        assert not basket.isV3()
+        assert basket.apiVersion == "v1"
+        assert basket.amountTotalGross == 100.0
+
+    def test_v3_is_used_with_total_value_gross(self, fixture_json):
+        basket = Basket.fromDict(fixture_json("basket_v3"))
+        assert basket.isV3()
+        assert basket.apiVersion == "v3"
+        assert basket.totalValueGross == 100.0
+
+    def test_v1_serialisation_carries_the_v1_amounts(self):
+        basket = Basket(amountTotalGross=100.0, amountTotalVat=15.97, currencyCode="EUR")
+        data = basket.serialize()
+        assert data["amountTotalGross"] == 100.0
+        assert "totalValueGross" not in data
+
+    def test_v3_serialisation_carries_only_the_v3_amount(self):
+        basket = Basket(totalValueGross=100.0, currencyCode="EUR")
+        data = basket.serialize()
+        assert data["totalValueGross"] == 100.0
+        assert "amountTotalGross" not in data
+
+    def test_missing_amounts_stay_none(self):
+        basket = Basket.fromDict({"id": "s-bsk-1", "currencyCode": "EUR"})
+        assert basket.amountTotalGross is None
+        assert basket.totalValueGross is None
+
+    def test_basket_items_are_parsed(self, fixture_json):
+        basket = Basket.fromDict(fixture_json("basket_v1"))
+        assert len(basket.basketItems) == 1
+        assert isinstance(basket.basketItems[0], BasketItem)
+        assert basket.basketItems[0].title == "Custom print t-shirt"
+
+
+class TestCustomer:
+
+    def test_round_trip_from_api_response(self, fixture_json):
+        customer = Customer.fromDict(fixture_json("customer"))
+        assert customer.key == "s-cst-cd1e6a11c02a"
+        assert customer.firstname == "Manuel"
+        assert isinstance(customer.billingAddress, Address)
+        assert customer.billingAddress.city == "Heidelberg"
+
+    def test_addresses_are_objects_even_when_empty(self, fixture_json):
+        """The API answers with an empty address object, never with a string."""
+        customer = Customer.fromDict({
+            **fixture_json("customer"),
+            "billingAddress": {"name": "", "street": "", "state": "", "zip": "",
+                               "city": "", "country": ""},
+        })
+        assert isinstance(customer.billingAddress, Address)
+        assert customer.billingAddress.city == ""
+
+    @pytest.mark.parametrize("value,expected", [
+        ("1990-01-24", datetime.datetime(1990, 1, 24)),
+        ("24.01.1990", datetime.datetime(1990, 1, 24)),
+        (datetime.date(1990, 1, 24), datetime.date(1990, 1, 24)),
+        (None, None),
+        ("", None),
+    ])
+    def test_birth_date_accepts_both_formats(self, value, expected):
+        assert Customer(firstname="A", lastname="B", birthDate=value).birthDate == expected
+
+    def test_invalid_birth_date_raises(self):
+        with pytest.raises(TypeError):
+            Customer(firstname="A", lastname="B", birthDate="24/01/1990")
+
+    def test_serialised_birth_date_is_iso(self):
+        customer = Customer(firstname="A", lastname="B", birthDate="24.01.1990")
+        assert customer.serialize()["birthDate"] == "1990-01-24"
+
+    @pytest.mark.parametrize("value", [Salutation.MR, Salutation.MRS, Salutation.UNKNOWN])
+    def test_valid_salutations(self, value):
+        assert Customer(firstname="A", lastname="B", salutation=value).salutation == value
+
+    def test_invalid_salutation_raises(self):
+        with pytest.raises(TypeError):
+            Customer(firstname="A", lastname="B", salutation="herr")
+
+    def test_missing_salutation_defaults_to_unknown(self):
+        assert Customer(firstname="A", lastname="B").salutation == Salutation.UNKNOWN
+
+    def test_key_or_customer_id_prefers_the_key(self):
+        customer = Customer(firstname="A", lastname="B", key="s-cst-1", customerId="mine")
+        assert customer.keyOrCustomerId == "s-cst-1"
+
+
+class TestAddress:
+
+    def test_name_is_split_into_first_and_lastname(self):
+        address = Address.fromDict({"name": "Manuel Weissmann", "street": "", "state": "",
+                                   "zip": "", "city": "", "country": ""})
+        assert (address.firstname, address.lastname) == ("Manuel", "Weissmann")
+
+    def test_single_word_name_leaves_lastname_empty(self):
+        address = Address.fromDict({"name": "Prince", "street": "", "state": "",
+                                    "zip": "", "city": "", "country": ""})
+        assert address.firstname == "Prince"
+        assert address.lastname is None
+
+    def test_serialisation_joins_the_name_and_renames_zip(self):
+        data = Address(firstname="Max", lastname="Mustermann", zipCode="10963").serialize()
+        assert data["name"] == "Max Mustermann"
+        assert data["zip"] == "10963", "the wire format calls it zip, not zipCode"
+
+
+class TestPaymentGetResponse:
+
+    def test_round_trip(self, fixture_json, client):
+        payment = PaymentGetResponse.fromDict(fixture_json("payment_get"), client)
+        assert payment.paymentId == "s-pay-123456"
+        assert payment.state is PaymentState.COMPLETED
+        assert payment.amountTotal == 100.0
+        assert payment.paymentType is PaymentTypes.CARD
+
+    def test_transactions_carry_enums_not_strings(self, fixture_json, client):
+        payment = PaymentGetResponse.fromDict(fixture_json("payment_get"), client)
+        assert [t.action for t in payment.transactions] == [Action.AUTHORIZE, Action.CHARGE]
+        assert all(t.status is TransactionStatus.SUCCESS for t in payment.transactions)
+
+    def test_transaction_ids_are_parsed_from_the_url(self, fixture_json, client):
+        payment = PaymentGetResponse.fromDict(fixture_json("payment_get"), client)
+        assert [t.transactionId for t in payment.transactions] == ["s-aut-1", "s-chg-1"]
+
+    def test_payment_type_from_type_id(self):
+        assert PaymentGetResponse.getPaymentTypeFromTypeId("s-crd-abc") is PaymentTypes.CARD
+
+    @pytest.mark.parametrize("type_id", ["", None, "nonsense", "s-xyz-abc"])
+    def test_invalid_type_id_raises(self, type_id):
+        with pytest.raises(ValueError):
+            PaymentGetResponse.getPaymentTypeFromTypeId(type_id)
+
+    def test_response_models_do_not_serialise(self, fixture_json, client):
+        payment = PaymentGetResponse.fromDict(fixture_json("payment_get"), client)
+        with pytest.raises(NotImplementedError):
+            payment.serialize()
+
+
+class TestPaymentRequest:
+
+    def test_serialisation_nests_the_resource_ids(self):
+        from unzer.model import Card
+        request = PaymentRequest(paymentType=Card(key="s-crd-1"), amount=10.0,
+                                 customerId="s-cst-1", basketId="s-bsk-1")
+        data = request.serialize()
+        assert data["resources"] == {
+            "customerId": "s-cst-1", "typeId": "s-crd-1",
+            "metadataId": None, "basketId": "s-bsk-1",
+        }
+
+    def test_currency_defaults_to_eur(self):
+        assert PaymentRequest().currency == "EUR"
+
+    def test_card3ds_must_be_boolean_or_none(self):
+        with pytest.raises(TypeError):
+            PaymentRequest(card3ds="yes")
+
+    def test_payment_type_is_required_before_a_request(self):
+        with pytest.raises(ValueError, match="paymentType"):
+            PaymentRequest().validateBeforeRequest()
+
+
+class TestPaymentPage:
+
+    def test_round_trip_from_api_response(self, fixture_json):
+        page = PaymentPageResponse.fromDict(fixture_json("paypage"))
+        assert page.payPageId == "s-ppg-1"
+        assert page.action is Action.CHARGE
+        assert page.paymentId == "s-pay-15"
+
+    @pytest.mark.parametrize("value", ["CHARGE", "charge", Action.CHARGE])
+    def test_action_accepts_both_casings_and_the_enum(self, value):
+        page = PaymentPage(action=value, amount=1.0, returnUrl="https://e.com/r")
+        assert page.action is Action.CHARGE
+
+    def test_invalid_action_raises(self):
+        with pytest.raises(TypeError):
+            PaymentPage(action="nonsense", amount=1.0, returnUrl="https://e.com/r")
+
+    def test_required_attributes_are_checked(self):
+        page = PaymentPage(action=Action.CHARGE, amount=None, returnUrl="https://e.com/r")
+        with pytest.raises(ValueError, match="amount"):
+            page.validateBeforeRequest()
+
+
+class TestWebhook:
+
+    def test_a_single_event_becomes_a_list(self):
+        assert Webhook(url="https://e.com/h", event=Events.CHARGE).event == [Events.CHARGE]
+
+    def test_plain_strings_are_accepted(self):
+        webhook = Webhook(url="https://e.com/h", event="charge.succeeded")
+        assert webhook.event == [Events.CHARGE_SUCCEEDED]
+
+    @pytest.mark.parametrize("value", ["nonsense", "unzer.model.webhook", "__module__"])
+    def test_invalid_events_are_rejected(self, value):
+        with pytest.raises(TypeError):
+            Webhook(url="https://e.com/h", event=value)
+
+    def test_serialisation_uses_event_list(self):
+        webhook = Webhook(url="https://e.com/h", event=[Events.CHARGE, Events.PAYMENT])
+        assert webhook.serialize() == {
+            "eventList": [Events.CHARGE, Events.PAYMENT],
+            "url": "https://e.com/h",
+        }
+
+    def test_url_is_required(self):
+        with pytest.raises(ValueError, match="url"):
+            Webhook(url=None).validateBeforeRequest()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -321,6 +321,7 @@ class TestTransactionTypesBeyondAuthorizeAndCharge:
         ("shipment", Action.SHIPMENT),
         ("payout", Action.PAYOUT),
         ("chargeback", Action.CHARGEBACK),
+        ("strong_customer_authentication", Action.SCA),
     ])
     def test_every_transaction_type_of_the_php_sdk_is_known(self, wire, expected):
         transaction = self._transaction(wire)
@@ -379,6 +380,16 @@ class TestUnknownEnumValuesRaise:
     def test_unknown_action_raises(self, value):
         with pytest.raises(ValueError):
             Action(value)
+
+    def test_action_covers_every_type_the_source_declares(self):
+        """Nine, not eight: TransactionTypes.php also has SCA. A missing member
+        makes getPayment() raise for the whole payment, so this list has to stay
+        complete — there is no fallback to absorb an omission."""
+        assert {a.value for a in Action} == {
+            "authorize", "preauthorize", "charge", "cancel-authorize",
+            "cancel-charge", "shipment", "payout", "chargeback",
+            "strong_customer_authentication",
+        }
 
     def test_unknown_transaction_type_in_a_response_raises(self):
         with pytest.raises(ValueError, match="brandnew"):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,514 @@
+"""One test per fixed bug.
+
+Every test in here fails on the code as it was before the fix, and the docstring
+names what went wrong. Verified against the sandbox where the API was involved --
+see AGENTS.md on why the API, and not the documentation, is the reference.
+"""
+
+import pytest
+import requests
+import responses
+
+from unzer.model import (
+    Action,
+    Address,
+    Customer,
+    Events,
+    PaymentGetResponse,
+    PaymentPage,
+    PaymentPageResponse,
+    PaymentRequest,
+    PaymentType,
+    PaymentTypes,
+    TransactionStatus,
+    Webhook,
+)
+
+BASE = "https://api.unzer.com/v1"
+
+
+class TestPaymentPageWasUnusable:
+    """The enum migration in 9fdc60c broke all three paypage paths."""
+
+    def test_action_enum_is_not_interpolated_into_the_url(self, client, fixture_json):
+        """Was "paypage/Action.CHARGE" -> HTTP 405 API.000.000.006 from the API."""
+        responses.start()
+        try:
+            responses.add(responses.POST, f"{BASE}/paypage/charge", json=fixture_json("paypage"))
+            page = PaymentPage(action=Action.CHARGE, amount=100.0,
+                               returnUrl="https://shop.example.com/return")
+            client.createPaymentPage(page)
+            assert responses.calls[0].request.url == f"{BASE}/paypage/charge"
+        finally:
+            responses.stop()
+            responses.reset()
+
+    def test_response_with_upper_case_action_parses(self, fixture_json):
+        """The API answers action="CHARGE"; the constructor only took enum members."""
+        assert fixture_json("paypage")["action"] == "CHARGE"
+        page = PaymentPageResponse.fromDict(fixture_json("paypage"))
+        assert page.action is Action.CHARGE
+
+    def test_card3ds_may_be_omitted(self):
+        """Default None hit `not isinstance(card3ds, bool)` -- every plain call raised."""
+        page = PaymentPage(action=Action.CHARGE, amount=100.0, returnUrl="https://e.com/r")
+        assert page.card3ds is None
+
+    def test_card3ds_still_rejects_nonsense(self):
+        with pytest.raises(TypeError):
+            PaymentPage(action=Action.CHARGE, amount=1.0, returnUrl="https://e.com/r",
+                        card3ds="yes")
+
+
+class TestChargedTransactionsWereAlwaysEmpty:
+
+    def test_transaction_action_is_an_enum(self, fixture_json, client):
+        """fromDict stored the lowercase string, so `txn.action == Action.CHARGE`
+        was always False and getChargedTransactions() returned []."""
+        payment = PaymentGetResponse.fromDict(fixture_json("payment_get"), client)
+        charge = [t for t in payment.transactions if t.action is Action.CHARGE]
+        assert len(charge) == 1
+        assert charge[0].status is TransactionStatus.SUCCESS
+
+    @responses.activate
+    def test_get_charged_transactions_finds_the_charge(self, fixture_json, client):
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-123456/charges/s-chg-1",
+                      json=fixture_json("charge"))
+        payment = PaymentGetResponse.fromDict(fixture_json("payment_get"), client)
+        assert len(payment.getChargedTransactions()) == 1
+
+
+class TestCustomerWithoutAddresses:
+
+    def test_missing_addresses_serialise_to_none(self):
+        """Sending "" made the API answer HTTP 400 API.410.300.007 ("HTTP message
+        not readable"), because the field is an object. null is accepted."""
+        data = Customer(firstname="A", lastname="B").serialize()
+        assert data["billingAddress"] is None
+        assert data["shippingAddress"] is None
+
+    def test_present_addresses_still_serialise_to_objects(self):
+        customer = Customer(firstname="A", lastname="B",
+                            billingAddress=Address(firstname="A", lastname="B", city="Berlin"))
+        assert customer.serialize()["billingAddress"]["city"] == "Berlin"
+
+    def test_wrong_address_type_raises_instead_of_asserting(self):
+        """Was a bare `assert`, which vanishes under `python -O`."""
+        customer = Customer(firstname="A", lastname="B", billingAddress="Hauptstr. 1")
+        with pytest.raises(TypeError, match="billingAddress"):
+            customer.serialize()
+
+
+class TestWebhookEvents:
+
+    @pytest.mark.parametrize("member,expected", [
+        (Events.AUTHORIZE_PENDING, "authorize.pending"),
+        (Events.CHARGE_PENDING, "charge.pending"),
+    ])
+    def test_pending_events_are_spelled_correctly(self, member, expected):
+        """Were "authorize.pendin" and "charge.pendin" -- registered but never fired."""
+        assert member == expected
+
+    @pytest.mark.parametrize("name", [
+        "preauthorize", "preauthorize.succeeded", "preauthorize.failed",
+        "preauthorize.pending", "preauthorize.canceled", "preauthorize.expired",
+        "authorize.resumed", "charge.resumed",
+    ])
+    def test_events_missing_before_are_available(self, name):
+        assert Events(name).value == name
+
+    def test_setter_no_longer_accepts_class_internals(self):
+        """Validation went against vars(Events).values(), which also contains
+        __module__ and __qualname__, so those strings passed as valid events."""
+        with pytest.raises(TypeError):
+            Webhook(url="https://e.com/h", event="unzer.model.webhook")
+
+
+class TestWebhookListsWereIterators:
+
+    @responses.activate
+    def test_list_webhooks_can_be_used_twice(self, client, fixture_json):
+        """Returned a map object: len() failed and a second pass was empty."""
+        responses.add(responses.GET, f"{BASE}/webhooks", json=fixture_json("webhooks_list"))
+        hooks = client.listWebhooks()
+        assert len(hooks) == 2
+        assert len(list(hooks)) == 2, "the result was consumed by the first pass"
+
+
+class TestUnknownPaymentTypePlaceholder:
+
+    def test_placeholder_raises_a_readable_error(self):
+        """method_name used to be the plain string "N/A", so the client crashed
+        with AttributeError: 'str' object has no attribute 'value'."""
+        cls = PaymentType.construct(PaymentTypes.GIROPAY)
+        with pytest.raises(NotImplementedError, match="no implementation"):
+            cls.method_name.value
+
+    def test_placeholder_class_has_a_usable_name(self):
+        """Was "Paymenttypes.Giropay"."""
+        assert PaymentType.construct(PaymentTypes.GIROPAY).__name__ == "GiropayPaymentType"
+
+
+class TestRetryOnNonIdempotentMethods:
+    """Issue #7: a retried POST can repeat a payment operation."""
+
+    @responses.activate
+    def test_post_is_not_repeated_after_a_timeout(self, retrying_client):
+        responses.add(responses.POST, f"{BASE}/customers", body=requests.exceptions.ReadTimeout())
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            retrying_client.createCustomer(Customer(firstname="A", lastname="B"))
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_get_is_still_repeated(self, retrying_client, fixture_json):
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1",
+                      body=requests.exceptions.ReadTimeout())
+        responses.add(responses.GET, f"{BASE}/payments/s-pay-1", json=fixture_json("payment_get"))
+        retrying_client.getPayment("s-pay-1")
+        assert len(responses.calls) == 2
+
+
+class TestTransactionUrlParsing:
+
+    @pytest.mark.parametrize("url,expected", [
+        (f"{BASE}/payments/s-pay-1/charges/s-chg-1/cancels/s-cnl-1", "cancels"),
+        # Hyphenated sub-operations were silently dropped by [a-z]+
+        (f"{BASE}/payments/s-pay-1/charges/s-chg-1/chargeback-reversal/s-cbr-1",
+         "chargeback-reversal"),
+        (f"{BASE}/payments/s-pay-1/charges/s-chg-1/due-date-extensions/s-dde-1",
+         "due-date-extensions"),
+    ])
+    def test_hyphenated_sub_operations_are_kept(self, url, expected):
+        from unzer.model.payment import paymentUrlRe
+        assert paymentUrlRe.match(url).groupdict()["subSubOperation"] == expected
+
+    @pytest.mark.parametrize("host", ["api.unzer.com", "sbx-api.unzer.com"])
+    def test_host_is_not_pinned(self, host):
+        """The pattern was anchored to api.unzer.com/v1 and failed on any other host."""
+        from unzer.model.payment import paymentUrlRe
+        url = f"https://{host}/v1/payments/s-pay-1/charges/s-chg-1"
+        assert paymentUrlRe.match(url) is not None
+
+    def test_missing_url_raises_a_value_error(self, client):
+        """Was a bare `assert`, so it disappeared under `python -O`."""
+        from unzer.model.payment import PaymentTransaction
+        with pytest.raises(ValueError, match="no url"):
+            PaymentTransaction.fromDict({"url": "", "status": "success", "type": "charge",
+                                         "date": "2026-08-21 10:15:32", "amount": "1.0"})
+
+
+class TestTypeIdParsing:
+
+    @pytest.mark.parametrize("type_id", ["nonsense", "s-crd", "x"])
+    def test_malformed_type_id_raises_value_error(self, type_id):
+        """"nonsense".split("-")[1] raised IndexError instead of a readable error."""
+        with pytest.raises(ValueError, match="Invalid typeId"):
+            PaymentGetResponse.getPaymentTypeFromTypeId(type_id)
+
+    @pytest.mark.parametrize("type_id", ["", None])
+    def test_empty_type_id_raises(self, type_id):
+        with pytest.raises(ValueError, match="Invalid typeId"):
+            PaymentGetResponse.getPaymentTypeFromTypeId(type_id)
+
+    def test_unknown_short_code_says_what_to_do(self):
+        """No placeholder return value: the message names the fix instead."""
+        with pytest.raises(ValueError, match="has to be added to PaymentTypes"):
+            PaymentGetResponse.getPaymentTypeFromTypeId("s-xyz-abc123")
+
+    @pytest.mark.parametrize("type_id,expected", [
+        ("s-crd-abc123", "CARD"),
+        ("p-sdd-abc123", "SEPA_DIRECT_DEBIT"),
+        ("s-pit-abc123", "PAYLATER_INSTALLMENT"),
+        ("s-obp-abc123", "OPEN_BANKING"),
+    ])
+    def test_known_short_codes(self, type_id, expected):
+        assert PaymentGetResponse.getPaymentTypeFromTypeId(type_id).name == expected
+
+
+class TestKeypairWithSeveralConfigurations:
+
+    @responses.activate
+    def test_all_configurations_are_returned(self, client):
+        """A keypair can hold the same payment type more than once -- observed with
+        card, twice, with different brands. get_configuration() silently returned
+        whichever came first."""
+        responses.add(responses.GET, f"{BASE}/keypair/types", json={"paymentTypes": [
+            {"type": "card", "supports": [{"channel": "chan-a", "brands": ["VISA"]}]},
+            {"type": "card", "supports": [{"channel": "chan-b", "brands": ["MASTER"]}]},
+        ]})
+        from unzer.model import Card
+        assert len(Card(client=client).get_configurations()) == 2
+
+    @responses.activate
+    def test_casing_is_ignored(self, client):
+        """The API answers "EPS" while the resource path is "eps"."""
+        responses.add(responses.GET, f"{BASE}/keypair/types", json={"paymentTypes": [
+            {"type": "EPS", "supports": [{"channel": "chan", "brands": []}]},
+        ]})
+        from unzer.model import Eps
+        assert Eps(client=client).get_configuration()["type"] == "EPS"
+
+    @responses.activate
+    def test_unconfigured_type_raises_lookup_error(self, client):
+        responses.add(responses.GET, f"{BASE}/keypair/types", json={"paymentTypes": []})
+        from unzer.model import Card
+        with pytest.raises(LookupError):
+            Card(client=client).get_configurations()
+
+
+class TestChannelPerBrand:
+    """A real keypair holds two card entries: MASTER/VISA and AMEX, on different
+    channels. get_channel_id() returned whichever came first, so callers got the
+    wrong channel for every brand but the first."""
+
+    @pytest.fixture
+    def keypair(self, fixture_json):
+        responses.add(responses.GET, f"{BASE}/keypair/types",
+                      json=fixture_json("keypair_types_multi_card"))
+
+    @responses.activate
+    def test_channel_is_selected_by_brand(self, client, keypair):
+        from unzer.model import Card
+        card = Card(client=client)
+        assert card.get_channel_id(brand="VISA") == "a" * 32
+        assert card.get_channel_id(brand="AMEX") == "b" * 32
+
+    @responses.activate
+    def test_brand_matching_ignores_casing(self, client, keypair):
+        from unzer.model import Card
+        assert Card(client=client).get_channel_id(brand="amex") == "b" * 32
+
+    @responses.activate
+    def test_brands_are_scoped_to_the_selected_configuration(self, client, keypair):
+        from unzer.model import Card
+        assert Card(client=client).get_brands(brand="AMEX") == ["AMEX"]
+
+    @responses.activate
+    def test_unknown_brand_names_the_available_ones(self, client, keypair):
+        from unzer.model import Card
+        with pytest.raises(LookupError, match="AMEX"):
+            Card(client=client).get_channel_id(brand="DINERS")
+
+    @responses.activate
+    def test_without_brand_the_first_entry_still_wins(self, client, keypair):
+        """Kept for backwards compatibility -- but it now logs a warning."""
+        from unzer.model import Card
+        assert Card(client=client).get_channel_id() == "a" * 32
+
+    @responses.activate
+    def test_single_configuration_needs_no_brand(self, client, keypair):
+        from unzer.model import Eps
+        assert Eps(client=client).get_channel_id() == "c" * 32
+
+
+class TestTransactionTypesBeyondAuthorizeAndCharge:
+    """A payment lists every transaction it has, not only the two this SDK creates.
+
+    Converting `type` to the Action enum initially only knew charge and authorize,
+    so getPayment() raised ValueError for any payment that had been cancelled,
+    shipped or paid out -- worse than the silent bug it replaced.
+
+    Which makes completeness the fix, not tolerance: all eight types the API knows
+    are declared, so a payment reads back whatever happened to it.
+    """
+
+    @pytest.mark.parametrize("wire,expected", [
+        ("authorize", Action.AUTHORIZE),
+        ("preauthorize", Action.PREAUTHORIZE),
+        ("charge", Action.CHARGE),
+        ("cancel-authorize", Action.REVERSAL),
+        ("cancel-charge", Action.REFUND),
+        ("shipment", Action.SHIPMENT),
+        ("payout", Action.PAYOUT),
+        ("chargeback", Action.CHARGEBACK),
+    ])
+    def test_every_transaction_type_of_the_php_sdk_is_known(self, wire, expected):
+        transaction = self._transaction(wire)
+        assert transaction.action is expected
+
+    @pytest.mark.parametrize("wire,expected", [
+        ("success", TransactionStatus.SUCCESS),
+        ("pending", TransactionStatus.PENDING),
+        ("error", TransactionStatus.ERROR),
+        ("resumed", TransactionStatus.RESUMED),
+    ])
+    def test_every_transaction_status_is_known(self, wire, expected):
+        from unzer.model.payment import PaymentTransaction
+        transaction = PaymentTransaction.fromDict({
+            "type": "charge", "status": wire, "date": "2026-08-21 10:15:32",
+            "amount": "1.0000", "participantId": "",
+            "url": "https://api.unzer.com/v1/payments/s-pay-1/charges/s-chg-1",
+        })
+        assert transaction.status is expected
+
+    @pytest.mark.parametrize("code", [0, 1, 2, 3, 4, 5, 6])
+    def test_known_payment_states(self, code):
+        from unzer.model import PaymentState
+        assert PaymentState(code).value == code
+
+    def test_unknown_payment_state_raises(self, fixture_json, client):
+        """No fallback here, on purpose. There are seven states and they have been
+        stable for years; an eighth is news, and swallowing it into UNKNOWN would
+        surface later as "not COMPLETED, so not paid" without saying why."""
+        from unzer.model import PaymentGetResponse
+        data = fixture_json("payment_get")
+        data["state"] = {"id": 99, "name": "something-new"}
+        with pytest.raises(ValueError, match="99"):
+            PaymentGetResponse.fromDict(data, client)
+
+    @staticmethod
+    def _transaction(wire_type):
+        from unzer.model.payment import PaymentTransaction
+        return PaymentTransaction.fromDict({
+            "type": wire_type, "status": "success", "date": "2026-08-21 10:15:32",
+            "amount": "50.0000", "participantId": "",
+            "url": "https://api.unzer.com/v1/payments/s-pay-1/charges/s-chg-1/cancels/s-cnl-1",
+        })
+
+
+class TestUnknownEnumValuesRaise:
+    """An unknown enum value is a defect, not something to paper over.
+
+    A placeholder member would also be indistinguishable from a real one: the API
+    genuinely answers `salutation: "unknown"`, where it means "not known about this
+    customer" rather than "this SDK is behind". Letting ValueError through names the
+    offending value and points at the parsing code.
+    """
+
+    @pytest.mark.parametrize("value", ["cancel-everything", "chrage", ""])
+    def test_unknown_action_raises(self, value):
+        with pytest.raises(ValueError):
+            Action(value)
+
+    def test_unknown_transaction_type_in_a_response_raises(self):
+        with pytest.raises(ValueError, match="brandnew"):
+            self._transaction("brandnew")
+
+    def test_unknown_transaction_status_in_a_response_raises(self):
+        from unzer.model.payment import PaymentTransaction
+        with pytest.raises(ValueError, match="half-done"):
+            PaymentTransaction.fromDict({
+                "type": "charge", "status": "half-done", "date": "2026-08-21 10:15:32",
+                "amount": "1.0000", "participantId": "",
+                "url": "https://api.unzer.com/v1/payments/s-pay-1/charges/s-chg-1",
+            })
+
+    def test_caller_typo_raises(self):
+        with pytest.raises(TypeError):
+            PaymentPage(action="chrage", amount=1.0, returnUrl="https://e.com/r")
+
+    def test_salutation_unknown_is_a_real_value_not_a_placeholder(self):
+        """The API sends it, and it carries meaning: no salutation is known."""
+        from unzer.model.customer import Salutation
+        customer = Customer(firstname="A", lastname="B", salutation=Salutation.UNKNOWN)
+        assert customer.serialize()["salutation"] == "unknown"
+
+    @staticmethod
+    def _transaction(wire_type):
+        from unzer.model.payment import PaymentTransaction
+        return PaymentTransaction.fromDict({
+            "type": wire_type, "status": "success", "date": "2026-08-21 10:15:32",
+            "amount": "50.0000", "participantId": "",
+            "url": "https://api.unzer.com/v1/payments/s-pay-1/charges/s-chg-1/cancels/s-cnl-1",
+        })
+
+
+class TestAmountRounding:
+    """The API takes Decimal{10,4}. Floats do not cooperate."""
+
+    def test_floating_point_residue_becomes_zero(self):
+        """12.3 - 10.0 - 2.3 is 8.88e-16, and json.dumps writes that in scientific
+        notation -- which is not a number this API accepts."""
+        import json
+        from unzer.model import SepaDirectDebit
+        residue = 12.3 - 10.0 - 2.3
+        assert residue != 0, "precondition: this is the IEEE-754 residue"
+        request = PaymentRequest(paymentType=SepaDirectDebit(key="s-sdd-1"), amount=residue)
+        assert request.serialize()["amount"] == 0.0
+        assert "e-" not in json.dumps(request.serialize())
+
+    def test_amount_is_capped_at_four_decimals(self):
+        from unzer.model import SepaDirectDebit
+        request = PaymentRequest(paymentType=SepaDirectDebit(key="s-sdd-1"), amount=1.23456789)
+        assert request.serialize()["amount"] == 1.2346
+
+    def test_paypage_amount_is_rounded(self):
+        page = PaymentPage(action=Action.CHARGE, amount=1.23456789,
+                           returnUrl="https://e.com/r")
+        assert page.serialize()["amount"] == 1.2346
+
+    @pytest.mark.parametrize("field", ["amountTotalGross", "amountTotalVat",
+                                       "amountTotalDiscount"])
+    def test_basket_v1_amounts_are_rounded(self, field):
+        from unzer.model import Basket
+        basket = Basket(**{field: 1.23456789}, currencyCode="EUR")
+        assert basket.serialize()[field] == 1.2346
+
+    def test_basket_v3_amount_is_rounded(self):
+        from unzer.model import Basket
+        basket = Basket(totalValueGross=1.23456789, currencyCode="EUR")
+        assert basket.serialize()["totalValueGross"] == 1.2346
+
+    @pytest.mark.parametrize("value,expected", [
+        (None, None), ("", None), ("1.5500", 1.55), (2, 2.0), (0, 0.0),
+    ])
+    def test_round_amount_edge_cases(self, value, expected):
+        from unzer.utils import roundAmount
+        assert roundAmount(value) == expected
+
+    def test_amounts_arrive_as_strings_from_the_api(self, fixture_json, client):
+        """Every amount in a response is a string with four decimals."""
+        raw = fixture_json("charge")
+        assert isinstance(raw["amount"], str)
+        from unzer.model.payment import PaymentResponse
+        assert PaymentResponse.fromDict(raw, client).amount == 100.0
+
+
+class TestInstallmentPlansTimestamp:
+    """getPaylaterInstallmentPlans() raised on every single call.
+
+    `expiresAt` was read as seconds because that is what the API reference shows
+    (`1735689599`, ten digits). The API answers with thirteen digits, milliseconds,
+    which lands in the year 58608 -- and this call is the first step of every
+    installment flow.
+    """
+
+    def test_milliseconds_are_parsed(self, fixture_json):
+        import datetime
+        from unzer.model import InstallmentPlans
+        plans = InstallmentPlans.fromDict(fixture_json("installment_plans"))
+        assert plans.expiresAt == datetime.datetime.fromtimestamp(1787349029.678)
+
+    def test_seconds_are_still_parsed(self, fixture_json):
+        """The reference shows seconds, so both units have to work."""
+        import datetime
+        from unzer.model import InstallmentPlans
+        data = fixture_json("installment_plans") | {"expiresAt": "1735689599"}
+        assert InstallmentPlans.fromDict(data).expiresAt == \
+            datetime.datetime.fromtimestamp(1735689599)
+
+    # Compared against fromtimestamp of the expected seconds rather than against a
+    # year: asserting a year here would only be green in one time zone.
+    @pytest.mark.parametrize("value,seconds", [
+        ("1787349029678", 1787349029.678),   # milliseconds, as the API sends them
+        (1787349029678, 1787349029.678),     # same, as a number
+        ("1735689599", 1735689599),          # seconds, as the reference shows them
+        (1735689599, 1735689599),
+    ])
+    def test_parse_timestamp_handles_both_units(self, value, seconds):
+        import datetime
+        from unzer.utils import parseTimestamp
+        assert parseTimestamp(value) == datetime.datetime.fromtimestamp(seconds)
+
+    @pytest.mark.parametrize("value", [None, ""])
+    def test_missing_timestamp_stays_none(self, value):
+        from unzer.utils import parseTimestamp
+        assert parseTimestamp(value) is None
+
+    def test_plans_are_parsed(self, fixture_json):
+        from unzer.model import InstallmentPlans
+        plans = InstallmentPlans.fromDict(fixture_json("installment_plans"))
+        assert plans.inquiryId
+        assert len(plans.plans) == 1
+        assert plans.plans[0].numberOfRates == 3
+        assert len(plans.plans[0].installmentRates) == 3


### PR DESCRIPTION
Stacked on #8 — merge that first, GitHub then retargets this to `develop`.

Ten bugs, every one reproduced against the sandbox rather than deduced from the docs. Four of
them only surfaced while writing the tests and examples in this PR.

| Bug | Effect before |
|---|---|
| Payment page interpolated the `Action` enum into the path | `405 API.000.000.006` — `createPaymentPage` and `getPaymentPage` both dead |
| `card3ds` validated with `isinstance(..., bool)` against a `None` default | every `PaymentPage()` without it raised |
| `Action` knew 2 of 8 transaction types | `getPayment()` raised for any payment ever cancelled, shipped or paid out |
| Transaction `action`/`status` stayed strings | `getChargedTransactions()` always returned `[]` |
| `billingAddress: ""` for a missing address | `400 API.410.300.007` — no customer without an address |
| `expiresAt` read as seconds, API sends milliseconds | `getPaylaterInstallmentPlans()` raised on every call, so Installment was unusable |
| Amounts serialised unrounded | `12.3 - 10.0 - 2.3` went out as `8.88e-16`, in scientific notation |
| `get_channel_id()` took the first matching keypair entry | wrong channel for AMEX on an account that configures `card` twice |
| `"authorize.pendin"` / `"charge.pendin"` | those two webhooks could not be registered |
| Retry ignored the HTTP method (#7) | a timed out POST could charge a customer twice |

Smaller things along the way: the transaction URL regex was pinned to `api.unzer.com/v1` and
silently dropped hyphenated sub-operations such as `chargeback-reversal`; `listWebhooks()`
returned a single-use `map` where the docstring promised a list; three `assert` used for
runtime validation, which vanish under `python -O`; `getPaymentTypeFromTypeId` raised
`IndexError` for an id without a hyphen; and `urllib3` was imported but never declared as a
dependency, shadowing the builtin `TimeoutError` and missing `ConnectTimeout`.

**On unknown enum values:** they raise, without a fallback. It means the SDK is behind the API,
which is worth seeing — and `unknown` is a real value elsewhere in this API (`salutation`), so
a placeholder of that name could not be told apart from one.

**Not fixed here, on purpose:** `DEBUG` logging still writes full payloads including IBANs.
That needs masking rather than a one-line change, and is tracked separately.

251 unit tests and 19 sandbox tests, green against three sandbox accounts with different
payment methods enabled.
