### PR TITLE
docs: Write a real README, a contributing guide and runnable examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,12 +169,18 @@ Do not make an enum tolerant via `_missing_` either. That applies to caller inpu
 a typo in our own code silently turns into a placeholder — which is how
 `PaymentPage(action="nonsense")` stopped failing once.
 
-Which makes completeness the actual requirement: `Action` declares all eight transaction types
+Which makes completeness the actual requirement: `Action` declares all nine transaction types
 of the API — `authorize`, `preauthorize`, `charge`, `cancel-authorize`, `cancel-charge`,
-`shipment`, `payout`, `chargeback` — even though this SDK can only create two of them. A
-payment lists every transaction it holds, so knowing only those two made `getPayment()` raise
-for every payment that had ever been cancelled, shipped or paid out. If Unzer adds a ninth,
-that is a release of this SDK, not a fallback.
+`shipment`, `payout`, `chargeback`, `strong_customer_authentication` — even though this SDK can
+only create two of them. A payment lists every transaction it holds, so knowing only those two
+made `getPayment()` raise for every payment that had ever been cancelled, shipped or paid out.
+If Unzer adds a tenth, that is a release of this SDK, not a fallback.
+
+Every enum carries a `.. seealso::` link to the file it mirrors, so completeness is checkable
+against the source instead of being a matter of memory. Where this SDK deliberately deviates
+from its source, the docstring says so and why — `PaymentTypes` drops the `UNKNOWN` member that
+the Java SDK uses as a parsing fallback. Deviating silently is how `Action` came to be missing
+a type in the first place.
 
 **Amounts are rounded to four decimals on serialisation** (`unzer.utils.roundAmount`). The API
 takes `Decimal{10,4}`, and float arithmetic does not cooperate: `12.3 - 10.0 - 2.3` is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,302 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. It covers what is specific to this
+project — the general code style lives in `.editorconfig` and `tox.ini`, the contribution
+workflow in `CONTRIBUTING.md`.
+
+## What this project is
+
+`unzer` is an **unofficial** Python SDK for the [Unzer](https://www.unzer.com) payment API.
+Unzer publishes official SDKs for PHP and Java, plus an unmaintained Node/TypeScript one —
+but none for Python. As far as we know this package is the only maintained Python SDK for
+Unzer, so downstream users have no fallback. Treat breaking changes and half-working code
+accordingly.
+
+Known downstream consumer: [viur-shop](https://github.com/viur-framework/viur-shop) depends on
+`unzer~=1.5` and uses both the client and the model classes directly. Renaming public API
+means coordinating a release there.
+
+## Verify against the API. Nothing else is authoritative.
+
+**The running API is the only source of truth for this project.** Unzer's documentation is
+wrong often enough that it cannot be trusted, and the official SDKs are wrong often enough
+that they cannot be trusted either. Both are hints about where to look. Neither is evidence.
+
+Before you implement a field, a required-ness, an endpoint version or an enum value: **call the
+sandbox and look at what comes back.** Before you "fix" something because a docs page says it
+is mandatory: call the sandbox and check whether the API agrees. If you cannot verify it, say
+so in the commit message or the docstring instead of presenting it as fact.
+
+Measured examples of the documentation and the SDKs being wrong — all of these were confirmed
+by real sandbox calls, and every one of them would have produced a wrong change if the docs
+had been believed:
+
+| Claim | Reality |
+|---|---|
+| Klarna requires `termsAndConditionUrl` and `privacyPolicyUrl` | Works without them |
+| Klarna requires a v2 basket | Runs on a v1 basket in production |
+| The header is `x-CLIENTIP` | It is `CLIENTIP` |
+| SEPA direct debit field is `accountHolder` | It is `holder` |
+| Direct bank transfer short code is `opb` | It is `obp` |
+| `types/openbanking-pis` takes an empty body | It takes `ibanCountry` |
+| `EPS` is spelled `eps` | The API answers `EPS`, the path is `eps` |
+| A keypair holds one config per payment type | It can hold several. One account has `card` twice: `MASTER`/`VISA` on one channel, `AMEX` on another — so the channel depends on the brand |
+| `additionalTransactionData` has four fields (Java SDK docs) | The API has eight |
+| `sandbox=True` needs the `sbx-api.unzer.com` host | Both hosts answer identically; the key prefix decides |
+| Sending `billingAddress: ""` for a missing address | HTTP 400 `API.410.300.007`; `null` works |
+| Paypage `action` comes back lower case | It comes back as `CHARGE` |
+| `expiresAt` of the installment plans is a unix timestamp in seconds (`1735689599`, per the API reference) | It is **milliseconds** (13 digits). Reading it as seconds lands in the year 58608 and raises |
+| The installment plans response is documented with seconds throughout | Mixed: `expiresAt` in ms, transaction dates as `YYYY-MM-DD HH:MM:SS` strings, rate dates as `YYYY-MM-DD` |
+| One response uses one type per boolean | `card3ds` is a bool while `billingAddressRequired` is the string `"false"` — same response |
+
+### How to verify
+
+Put a **sandbox** private key in a `.env` in the repository root (git-ignored) and run the
+sandbox tests:
+
+```bash
+echo 'UNZER_PRIVATE_KEY=s-priv-...' > .env
+pytest -m sandbox
+```
+
+Sandbox keys start with `s-priv-`, production keys with `p-priv-`. `tests/conftest.py` refuses
+to run with anything that is not a sandbox key, because the suite creates real transactions on
+whatever account it is pointed at. **Never point it at production**, and never commit a key.
+
+Note that sandbox accounts differ in which payment methods they have enabled — an account
+without `paylater-*` cannot verify the installment flow. Check `keypair/types` first.
+
+### Where to look before calling
+
+For finding out *what to try*, in this order:
+
+1. **`github.com/unzerdev/php-sdk`** — `src/Resources/PaymentTypes/*.php`. The URL slug is the
+   kebab-case class short name (`ResourceNameService::getClassShortNameKebapCase`).
+   Use branch `main`; the GitHub tree API needs it explicitly. `develop` is **dead** (last
+   commit 2024-02-07, 0 ahead / 96 behind `main`) — do not look there.
+2. **`github.com/unzerdev/java-sdk`** — `paymenttypes/*.java` (`getResourceUrl()`) and
+   `PaymentTypeEnum.java` for the short codes.
+3. **`https://api.unzer.com/swagger-ui/api-docs`** — the full OpenAPI spec; the API reference
+   page is only a ReDoc wrapper around it. Incomplete: `clicktopay` and `sofort` are missing
+   although both exist. Still the best written source for `additionalTransactionData`.
+4. `docs.unzer.com` — last, and only for prose and flow descriptions.
+
+Where sources contradict each other, resolve it with a sandbox call and note in the docstring
+which one turned out right — otherwise the next person cannot tell a decision from a mistake.
+
+### Further sources worth knowing
+
+```
+Test data — for tests and examples/, never invent card numbers:
+  https://docs.unzer.com/reference/test-cards/   # 3DS and frictionless PANs
+  https://docs.unzer.com/reference/test-data/    # IBANs, logins, PIN keywords, 2FA triggers
+
+Changelog — check before starting work on a resource:
+  https://docs.unzer.com/news/                   # /news/articles/ itself returns 403
+
+Mandatory field lists and step order, per payment method (treat as hints, not as truth):
+  https://docs.unzer.com/payment-methods/invoice/accept-unzer-invoice-upl-server-side-only-integration/
+  https://docs.unzer.com/payment-methods/installment/accept-unzer-installment-server-side-only-integration/
+  https://docs.unzer.com/payment-methods/klarna/accept-klarna-server-side-only-integration/
+  https://docs.unzer.com/payment-methods/direct-bank-transfer/manage-unzer-open-banking-payment/
+
+CCD2 two-factor risk check — documented as a mandatory redirect flow for the paylater types,
+not yet verified against the API:
+  https://docs.unzer.com/ccd2-2fa/
+
+Payment Page attribute keys, as a live generator:
+  https://demo.unzer.com/demo/resources/paypage_manual.html
+
+When a docs URL 404s — the site was restructured in April 2026:
+  https://docs.unzer.com/sitemap.xml
+```
+
+`api-reference-docs.unzer.com/reference` is a second, **older** API reference (Readme.io,
+OpenAPI 3.0.1, 111 paths against the Swagger spec's 151). Use it only as an archive for the
+legacy `sofort` and `pis` types and the PayPal PATCH models; it has no download endpoint, the
+spec sits as JSON inside the SSR HTML of every `/reference/*` page.
+
+## Deliberate design decisions that look like gaps
+
+**Payment types without payload fields are intentional.** `Card`, `Klarna`, `Ideal`,
+`PayPal`, `Applepay`, `Googlepay`, `ClickToPay` and others carry no fields even though their
+`types` endpoints accept some. These types are created client-side through the Payment Page or
+the UI components; only the resulting `typeId` comes back to the backend, so a server-side
+`createPaymentType()` with an empty body never occurs in those flows. For `Card` it is doubly
+deliberate: accepting raw card data would make the integration PCI-DSS liable.
+
+This has a consequence for testing: **these types cannot be exercised server-side.** Creating
+one yields an empty resource that the provider rejects further down the flow — Klarna answers
+`COR.800.400.160 "Validation error at partner system"`, which looks like an SDK bug and is not
+one. The sandbox tests therefore only drive types whose fields the SDK actually sends (SEPA
+direct debit, EPS, the paylater types, Wero, Direct Bank Transfer).
+
+Do not add fields to these classes. Server-side fields belong only to types that are actually
+created server-side — Installment, SEPA Direct Debit, Direct Bank Transfer.
+
+**camelCase is the current public API, on purpose for now.** Method and attribute names mirror
+the Unzer JSON payload (`getPayment`, `paymentId`, `amountTotalGross`). This is scheduled to
+change to snake_case in 2.0, together with a move to dataclasses. Until then: do not rename
+anything, and keep new *parameters* snake_case only where that is already the local convention
+(`api_version`, `client_ip`, `additional_transaction_data`).
+
+**Unzer offers no idempotency keys.** Neither OpenAPI spec contains an `Idempotency-Key`
+header, and `docs.unzer.com` has no mention of idempotency at all. A retried `POST` can
+therefore repeat a payment operation that already succeeded. Any change to the retry logic in
+`UnzerClient._request` must keep that in mind: retrying after the request has been sent is a
+double-charge risk, not a robustness feature.
+
+**A keypair can configure the same payment type more than once.** Reading the payment method
+configuration therefore needs a brand: `get_channel_id(brand="AMEX")`. Without it the first
+entry wins, which is silently the wrong channel for every other brand. `get_configurations()`
+returns all entries; `get_configuration()` keeps returning the first one for compatibility and
+logs a warning when there is more than one.
+
+Sandbox accounts also differ in which *fields* the keypair carries at all — `coreId` and
+`merchantAddress` on one, `productType` and `unzerId` on another. Anything reading the keypair
+must tolerate missing keys. And `allowCustomerTypes` is a comma-separated **string**
+(`"B2B,B2C"`), not a list.
+
+**An unknown enum value raises. There is no fallback anywhere.** It means this SDK is behind
+the API, which is a defect worth seeing: `ValueError` names the offending value and points at
+the parsing code, and the fix is to add the missing member.
+
+A placeholder member would also be ambiguous, because `unknown` is a **real** value in this
+API with a meaning of its own — `salutation: "unknown"` is what the API answers for a customer
+whose salutation is not known. A same-named placeholder could not be told apart from it.
+
+Do not make an enum tolerant via `_missing_` either. That applies to caller input as well, so
+a typo in our own code silently turns into a placeholder — which is how
+`PaymentPage(action="nonsense")` stopped failing once.
+
+Which makes completeness the actual requirement: `Action` declares all eight transaction types
+of the API — `authorize`, `preauthorize`, `charge`, `cancel-authorize`, `cancel-charge`,
+`shipment`, `payout`, `chargeback` — even though this SDK can only create two of them. A
+payment lists every transaction it holds, so knowing only those two made `getPayment()` raise
+for every payment that had ever been cancelled, shipped or paid out. If Unzer adds a ninth,
+that is a release of this SDK, not a fallback.
+
+**Amounts are rounded to four decimals on serialisation** (`unzer.utils.roundAmount`). The API
+takes `Decimal{10,4}`, and float arithmetic does not cooperate: `12.3 - 10.0 - 2.3` is
+`8.88e-16`, which `json.dumps` writes in scientific notation — not a number the API accepts.
+Amounts come back from the API as *strings* with four decimals (`"5.5500"`).
+
+**`Basket` intentionally supports two incompatible schemas.** v1 uses `amountTotalGross`, v3
+uses `totalValueGross`; setting the latter switches the basket to the v3 endpoint. Do not
+"clean this up" into one schema.
+
+Which version a payment method needs is a recurring source of confusion, and the
+documentation is not reliable here:
+
+| Method | Verified in practice | What the docs claim |
+|---|---|---|
+| `paylater-installment` | v3 | v3 |
+| `klarna` | **v1 works** — in production use via viur-shop | v2 |
+| `paylater-invoice` | not verified | v2 |
+| everything else | v1 | v1 |
+
+Basket v2 is not implemented (`Basket.apiVersion` only returns `v1` or `v3`), and so far
+nothing has needed it. v2 and v3 share one schema, so if a method ever does require v2, the v3
+model can build the body — only the endpoint version differs.
+
+**Do not "fix" a working integration because the documentation says a field or version is
+mandatory.** Unzer documents requirements that the API does not enforce. Two measured examples:
+Klarna runs without the `termsAndConditionUrl`/`privacyPolicyUrl` that its page calls
+mandatory, and it runs on a v1 basket. Check against a real sandbox call before changing
+anything on the strength of a docs page.
+
+## Code style
+
+- PEP 8, except for the naming discussed above and the ignore list in `tox.ini`
+  (`E121, E123, E126, E133, E226, E241, E242, E704, W503, W504, W505`).
+- Lines up to 120 characters. Spaces, LF, UTF-8, trailing newline — see `.editorconfig`.
+- Double quotes for strings, always.
+- Multi-line dicts and lists: one `key: value` per line, trailing comma on the last entry.
+- Type hints everywhere. Use `import typing as t`, built-in generics (`list[str]`, not
+  `t.List[str]`) and `X | None` instead of `t.Optional[X]`. Do not repeat types in the
+  docstring — the annotation is the single source of truth. Older modules still carry
+  `# type:` comments and `:type x:` docstring lines; those are legacy, do not add more.
+- Docstrings in Sphinx/reST format (`:param x:`, `:return:`, `.. seealso::`). No Google or
+  NumPy style.
+- **f-strings, without exception, in every line you write or touch** — including `logging`
+  calls. Much of the older code uses `%` formatting; leave those lines alone unless you are
+  changing them anyway, and never convert a line the other way round.
+- **`X | None`, never a bare `X = None`.** Older signatures are full of implicit Optional
+  (`client_ip: str = None`); do not add more, and fix the ones in lines you touch.
+- Do not remove commented-out code, `TODO`/`ToDo` notes or debug helpers that you did not add
+  yourself. If something looks obsolete, ask.
+- Executable `.py` and `.sh` files carry the `+x` bit, in git too.
+
+## Language
+
+Code, comments, docstrings, commit messages and all repository files are written in English.
+This is a public repository: it must contain no data, names or references from any customer
+project — not in code, not in comments, not in commit messages, not as "adapted from X"
+attribution. Everything here has to stand on its own.
+
+## Where documentation goes
+
+Four places, and the distinction matters:
+
+| Target | Audience | Content |
+|---|---|---|
+| `README.md` | users of the package | install, auth, quickstart, error handling, supported payment methods |
+| `docs/*.md` | users who need detail | per-topic reference that outgrew the README, e.g. `docs/payment-methods.md` |
+| `AGENTS.md` | agents | this file — pitfalls, sources, decisions that look like bugs |
+| `CONTRIBUTING.md` | contributors | workflow, style, release process |
+
+`docs/superpowers/` is git-ignored working material: brainstorming output, design specs,
+scratch notes. Nothing there is documentation, and nothing there should be committed.
+
+**When a design document produces knowledge worth keeping, rewrite it into `docs/` — do not
+commit the design document.** A file named `2026-08-05-some-feature-design.md` is a snapshot of
+one decision on one day: the date makes it look stale the moment it is merged, nobody updates
+it, and readers cannot tell whether it still describes the code. Permanent documentation is
+named after its subject, carries no date, and is edited when the code changes.
+
+## Commits and branches
+
+- [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`,
+  `refactor:`, `docs:`, `test:`, `cicd:`. Code identifiers in the subject may be written as
+  `` `code` ``.
+- Branch off before committing: `fix/*` for patch-level, `feat/*` for minor-level work.
+- Pull request target: fixes (patch level) go against `main`, features (minor level) against
+  `develop`.
+- Do not add `Co-Authored-By` trailers.
+- Commit only what belongs to the change at hand — no drive-by version bumps, no unrelated
+  reformatting.
+- Releases: bump `__version__`, commit as `chore: bump version to vX.Y.Z`, tag `vX.Y.Z`. The
+  publish workflow triggers on the tag; a `v-test-*` prefix targets TestPyPI.
+
+## Testing
+
+Run the test suite before committing. Unit tests mock HTTP and never call the real API:
+
+```bash
+pip install -e ".[testing]"
+pytest
+pycodestyle src/                    # full tree, not just the diff
+```
+
+Tests marked `@pytest.mark.sandbox` talk to the Unzer sandbox and skip unless
+`UNZER_PRIVATE_KEY` is set in the environment. Never commit keys — examples and tests read
+them from environment variables, without exception.
+
+Beware when writing tests against models: several `fromDict` implementations expect the exact
+response shape of the API, so use real captured payloads as fixtures rather than hand-written
+minimal dicts.
+
+## Things that are easy to get wrong here
+
+- `PaymentType.method` is the short code (`crd`), `method_name` is the URL slug (`card`). The
+  naming is unfortunate and inherited from Unzer, which is inconsistent about it too — the
+  same method appears as `EPS` and as `eps` depending on the endpoint.
+- Responses are parsed by `fromDict(data, client)`; request models use `serialize()`. Response
+  models raise `NotImplementedError` from `serialize()` by design.
+- `PaymentTransaction` derives its ids by parsing the transaction URL with a regex, because
+  the API does not return them as separate fields. Changing `UnzerClient.endpoint` therefore
+  affects parsing.
+- Errors can arrive with a 2xx status code and an `errors` list in the body — Unzer documents
+  this explicitly. Do not treat HTTP 200 as success without checking `isError`.
+- `logger.debug` output contains full request payloads, including IBANs and dates of birth.
+  Do not add payload logging above DEBUG level.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+## Before you change behaviour: measure it
+
+The single most important rule in this repository. Unzer's documentation is frequently wrong,
+and so are their official SDKs. **The running API is the only source of truth.** Before
+implementing a field, a required-ness, an endpoint version or an enum value, call the sandbox
+and look at what actually comes back. Before "fixing" something because a docs page calls a
+field mandatory, check whether the API enforces it.
+
+[AGENTS.md](AGENTS.md) lists thirteen measured cases where the documentation was wrong, along
+with the source ranking to use when looking things up.
+
+## Issues
+
+Please include the SDK version, the Python version, and — if there is one — the `errorId`
+(`s-err-…`) from the `ErrorResponse`. Unzer support can resolve those. Never paste private
+keys, and remember that `DEBUG` logs contain full payloads with IBANs and names.
+
+## Pull requests
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/), and the
+type determines the version bump:
+
+| Type | Meaning | Bump |
+|---|---|---|
+| `fix:` | bug fix | patch |
+| `feat:` | new feature | minor |
+| `refactor:`, `chore:`, `docs:`, `test:`, `cicd:` | no behaviour change | none |
+
+Add a `!` (`feat!:`) for a breaking change. Code identifiers in the subject may be written as
+`` `code` ``.
+
+Branch off before committing: `fix/*` for patch-level work, `feat/*` for minor-level work.
+Fixes target `main`, features target `develop`. Commit only what belongs to the change — no
+drive-by version bumps, no unrelated reformatting.
+
+## Code style
+
+- PEP 8, with the exceptions in `tox.ini` and one deliberate deviation: **method and attribute
+  names mirror the Unzer JSON payload** (`getPayment`, `paymentId`), because tracing a field
+  from the API reference into this code should not require a translation table. This is
+  scheduled to change to snake_case in 2.0.
+- Lines up to 120 characters, spaces, LF, trailing newline — see `.editorconfig`.
+- Double quotes. Multi-line dicts and lists: one entry per line, trailing comma.
+- Type hints everywhere. `import typing as t`, built-in generics (`list[str]`), `X | None`.
+  Do not repeat types in the docstring — the annotation is the single source of truth. Older
+  modules still carry `# type:` comments; those are legacy, do not add more.
+- Docstrings in Sphinx/reST format (`:param x:`, `:return:`). No Google or NumPy style.
+- An unknown enum value raises — it means the SDK is behind the API, and the fix is to add
+  the missing member, not to swallow it. Note that `unknown` is a real value in this API
+  (`salutation`), so a placeholder of that name would be ambiguous.
+
+## Setup and tests
+
+```bash
+uv sync --extra testing          # or: pip install -e ".[testing]"
+uv run pytest                    # unit tests, mocked, no network
+uv run pycodestyle src/ tests/   # the CI checks the full tree, not just the diff
+```
+
+Unit tests mock HTTP with [responses](https://pypi.org/project/responses/) and read their
+payloads from `tests/fixtures/`. **Build fixtures from real captured responses**, never by
+hand: a hand-written one only confirms what you believed while writing it. One of ours had
+`action: "charge"` where the API answers `"CHARGE"`.
+
+Sandbox tests talk to the real API and are opt-in:
+
+```bash
+echo 'UNZER_PRIVATE_KEY=s-priv-...' > .env    # git-ignored, never commit this
+uv run pytest -m sandbox
+```
+
+They create real resources on whatever account the key belongs to, so the suite refuses
+anything that is not a `s-priv-` key. Sandbox accounts differ in which methods they have
+enabled — tests skip what an account cannot do, so a skip is usually the account, not a bug.
+
+Every bug fix gets a regression test that fails before the fix. Tests must not depend on state
+an earlier run left behind in the sandbox; generate unique ids per run.
+
+## Releasing
+
+1. Bump `__version__` in `src/unzer/__init__.py`.
+2. Commit as `chore: bump version to vX.Y.Z`.
+3. Tag `vX.Y.Z` and push the tag.
+
+The publish workflow builds and uploads to PyPI and drafts a GitHub release. A `v-test-*`
+prefix targets TestPyPI instead and creates no public release. Pre-releases follow PEP 440
+(`1.6.0.dev1`, `1.6.0rc1`); a tag containing `dev` is marked as a prerelease automatically.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,239 @@
     <br>
     An unofficial python SDK for the payment service <a href="https://www.unzer.com">Unzer</a>.
 </div>
+
+> **Unofficial.** This package is not built or endorsed by Unzer. Unzer publishes SDKs for
+> [PHP](https://github.com/unzerdev/php-sdk) and [Java](https://github.com/unzerdev/java-sdk),
+> but none for Python.
+
+## Requirements
+
+Python 3.11 or newer. The only runtime dependency is
+[requests](https://pypi.org/project/requests/).
+
+## Installation
+
+```bash
+pip install unzer
+```
+
+## Authentication
+
+Unzer authenticates with the **private key** of a keypair, sent as the username of HTTP basic
+auth. Which environment a request reaches is decided by the key itself, not by the host:
+
+| Prefix | Environment |
+|---|---|
+| `s-priv-…` | sandbox |
+| `p-priv-…` | production |
+
+```python
+import unzer
+
+client = unzer.UnzerClient(
+    private_key="s-priv-...",
+    public_key="s-pub-...",
+    sandbox=True,     # informational: does not change the endpoint, see below
+)
+```
+
+`sandbox` does not switch hosts — `api.unzer.com` serves both environments. Keep it accurate
+anyway: consumers need to know which mode they are in, not least because the redirect URLs
+Unzer returns differ (`sbx-payment.unzer.com` versus `payment.unzer.com`).
+
+Never hardcode keys. The examples in [`examples/`](examples) read them from the environment.
+
+## Quickstart
+
+A Payment Page is the shortest complete flow: Unzer hosts the page, the customer picks a
+method there, and you never touch card data.
+
+```python
+import os
+import unzer
+from unzer.model import Action, PaymentPage
+
+client = unzer.UnzerClient(
+    private_key=os.environ["UNZER_PRIVATE_KEY"],
+    public_key=os.environ["UNZER_PUBLIC_KEY"],
+    sandbox=True,
+)
+
+page = client.createPaymentPage(PaymentPage(
+    action=Action.CHARGE,
+    amount=12.34,
+    currency="EUR",
+    returnUrl="https://shop.example.com/return",
+    orderId="my-order-1",
+    shopName="Example Shop",
+))
+
+print(page.redirectUrl)   # send the customer here
+print(page.paymentId)     # keep this to check the payment later
+```
+
+When the customer comes back, ask the API what happened — never trust the return URL alone:
+
+```python
+payment = client.getPayment(page.paymentId)
+print(payment.state)          # CREATE right after init, then PENDING / COMPLETED / ...
+print(payment.amountCharged)
+```
+
+A payment starts out as `PaymentState.CREATE` and only becomes `PENDING` once the customer
+engages with the page, so treat anything but `COMPLETED` as "not paid yet".
+
+### Charging a payment method directly
+
+Methods whose data the SDK can send itself — see the table below — work without a Payment Page:
+
+```python
+from unzer.model import PaymentRequest, SepaDirectDebit
+
+response = client.charge(PaymentRequest(
+    paymentType=SepaDirectDebit(
+        iban="DE89370400440532013000",
+        bic="COBADEFFXXX",
+        holder="Maximilian Mustermann",
+    ),
+    amount=12.34,
+    currency="EUR",
+    returnUrl="https://shop.example.com/return",
+    orderId="my-order-2",
+))
+
+if response.isSuccess:
+    print(response.transactionId, response.processing.shortId)
+elif response.isPending:
+    print("customer has to confirm:", response.redirectUrl)
+```
+
+The payment type is created at Unzer as part of this call if it has no `key` yet.
+
+## Testing against the sandbox
+
+Use a `s-priv-` key and the
+[official test data](https://docs.unzer.com/reference/test-data/) — test cards, IBANs and the
+logins for the redirect flows. Do not invent card numbers; they will be declined.
+
+## Error handling
+
+Any 4xx response raises `ErrorResponse`. It carries the whole error payload, and Unzer's
+`merchantMessage` is the field worth logging — `customerMessage` is meant to be shown to the
+customer and is translated according to the `language` you pass to the client.
+
+```python
+from unzer.model import ErrorResponse
+
+try:
+    client.charge(payment_request)
+except ErrorResponse as error:
+    print(error.statusCode)          # 400
+    print(error.errorId)             # s-err-... , quote this to Unzer support
+    for entry in error.errors:
+        print(entry.code)            # API.320.200.145
+        print(entry.merchantMessage) # Basket is already in use.
+        print(entry.customerMessage)
+```
+
+Two things to know. A response can carry `errors` **with a 2xx status code**, which the SDK
+also raises for. And a pending payment is not an error: `isPending` with a `redirectUrl` means
+the customer has to confirm somewhere, and you have to follow up with `getPayment()`.
+
+## Supported payment methods
+
+All 24 payment methods Unzer currently offers. `method_name` is the slug in the `types/` path,
+`method` the short code that appears in a type id such as `s-crd-abc123`.
+
+Seven of them accept data from the server; the rest are created **client-side** through the
+Payment Page or Unzer's UI components, which hand you a ready `typeId`. Those classes
+deliberately carry no fields — for cards, accepting raw card data would make your integration
+PCI-DSS liable.
+
+| Class | `types/` slug | Code | Fields the SDK sends |
+|---|---|---|---|
+| `Alipay` | `alipay` | `ali` | — |
+| `Applepay` | `applepay` | `apl` | — |
+| `Bancontact` | `bancontact` | `bct` | `holder` |
+| `Card` | `card` | `crd` | — |
+| `ClickToPay` | `clicktopay` | `ctp` | — |
+| `Eps` | `eps` | `eps` | `bic` |
+| `Googlepay` | `googlepay` | `gop` | — |
+| `Ideal` | `ideal` | `idl` | — |
+| `Klarna` | `klarna` | `kla` | — |
+| `OpenbankingPis` | `openbanking-pis` | `obp` | `ibanCountry` |
+| `PayPal` | `paypal` | `ppl` | — |
+| `PayU` | `payu` | `pyu` | — |
+| `PaylaterDirectDebit` | `paylater-direct-debit` | `pdd` | `iban`, `holder`, `country` |
+| `PaylaterInstallment` | `paylater-installment` | `pit` | `inquiryId`, `numberOfRates`, `iban`, `country`, `holder` |
+| `PaylaterInvoice` | `paylater-invoice` | `piv` | — |
+| `PostFinanceCard` | `post-finance-card` | `pfc` | — |
+| `PostFinanceEfinance` | `post-finance-efinance` | `pfe` | — |
+| `Prepayment` | `prepayment` | `ppy` | — |
+| `Przelewy24` | `przelewy24` | `p24` | — |
+| `SepaDirectDebit` | `sepa-direct-debit` | `sdd` | `iban`, `bic`, `holder` |
+| `Sofort` | `sofort` | `sft` | — |
+| `Twint` | `twint` | `twt` | — |
+| `Wechatpay` | `wechatpay` | `wcp` | — |
+| `Wero` | `wero` | `wro` | `walletId` |
+
+`Sofort` and `giropay` are being discontinued by Unzer; the deprecated legacy types
+(`invoice`, `invoice-secured`, `installment-secured`, `sepa-direct-debit-secured`) are not
+implemented.
+
+## What the SDK covers
+
+| | |
+|---|---|
+| Resources | customers, baskets (v1 and v3), payment types, payment pages, webhooks, keypair |
+| Transactions | `authorize`, `charge` |
+| Extras | installment plans, installment risk check, additional transaction data |
+
+**Not implemented yet:** cancellations and refunds, shipments, payouts, recurring payments,
+the metadata resource, chargeback retrieval, and Payment Page v2 / LinkPay. A payment that was
+cancelled or shipped elsewhere still reads back correctly — the transaction types are known,
+they just cannot be created here.
+
+## Logging
+
+Everything logs below `unzer-sdk`:
+
+```python
+import logging
+logging.getLogger("unzer-sdk").setLevel(logging.DEBUG)
+```
+
+**`DEBUG` logs complete request and response bodies**, including IBANs, card holder names and
+dates of birth. Do not enable it in production without knowing where those logs end up.
+
+## Documentation
+
+This README is the SDK documentation. For the API itself, see Unzer's own:
+
+- [API basics](https://docs.unzer.com/server-side-integration/api-basics/) — auth, errors, notifications
+- [API reference](https://api.unzer.com/api-reference/index.html)
+- [Payment methods](https://docs.unzer.com/payment-methods/) — the flow each method requires
+- [Test data](https://docs.unzer.com/reference/test-data/)
+
+## Development
+
+```bash
+uv sync --extra testing          # or: pip install -e ".[testing]"
+uv run pytest                    # unit tests, no network
+uv run pycodestyle src/ tests/
+```
+
+The sandbox tests are opt-in and need a sandbox key:
+
+```bash
+echo 'UNZER_PRIVATE_KEY=s-priv-...' > .env    # git-ignored
+uv run pytest -m sandbox
+```
+
+They create real resources on whatever account the key belongs to, so the suite refuses to run
+with anything but a `s-priv-` key. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and
+[AGENTS.md](AGENTS.md) for the pitfalls this API has in store.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/payment-methods.md
+++ b/docs/payment-methods.md
@@ -1,0 +1,141 @@
+# Payment methods
+
+Which payment methods this SDK covers, how their data reaches Unzer, and which
+peculiarities each one carries. Everything here is measured against the sandbox unless
+marked otherwise — Unzer's documentation is not reliable on these points, see
+[AGENTS.md](../AGENTS.md).
+
+## Two ways a payment type is created
+
+This is the distinction that explains most of the code, and most of the confusion.
+
+**Server-side.** Your backend sends the payment data (an IBAN, a BIC) to
+`POST /v1/types/<slug>` and gets a `typeId` back. Seven of the 24 methods work this way,
+and their classes carry the corresponding fields.
+
+**Client-side.** The Payment Page or one of Unzer's
+[UI components](https://docs.unzer.com/online-payments/ui-component/) collects the data
+in the browser, sends it to Unzer directly, and hands your backend the finished
+`typeId`. The remaining 17 methods work this way, and their classes deliberately carry
+**no fields** — there is nothing for the server to send.
+
+For cards this is not just a convention: accepting raw card numbers on your own server
+would put your integration under PCI-DSS obligations. The same reasoning applies to
+Apple Pay and Google Pay, whose payload is a signed token that only the browser or the
+wallet can produce.
+
+**Consequence for the SDK:** creating a client-side type server-side produces an empty
+resource. The call itself succeeds, and the failure surfaces much later, during the
+authorization, as an error from the provider that looks like an SDK bug — Klarna answers
+`COR.800.400.160 "Validation error at partner system"`. If you are debugging that, check
+where the `typeId` came from.
+
+## The methods
+
+`method_name` is the slug in the `types/` path, `method` the short code that appears in
+a type id (`s-crd-abc123`). Both are enums on the class: `Card.method_name.value` is
+`"card"`, `Card.method.value` is `"crd"`.
+
+| Class | Slug | Code | Created | Fields |
+|---|---|---|---|---|
+| `Alipay` | `alipay` | `ali` | client | — |
+| `Applepay` | `applepay` | `apl` | client | — |
+| `Bancontact` | `bancontact` | `bct` | server | `holder` (optional) |
+| `Card` | `card` | `crd` | client | — (PCI-DSS) |
+| `ClickToPay` | `clicktopay` | `ctp` | client | — |
+| `Eps` | `eps` | `eps` | server | `bic` (optional) |
+| `Googlepay` | `googlepay` | `gop` | client | — |
+| `Ideal` | `ideal` | `idl` | client | — |
+| `Klarna` | `klarna` | `kla` | client | — |
+| `OpenbankingPis` | `openbanking-pis` | `obp` | server | `ibanCountry` |
+| `PayPal` | `paypal` | `ppl` | client | — |
+| `PayU` | `payu` | `pyu` | client | — |
+| `PaylaterDirectDebit` | `paylater-direct-debit` | `pdd` | server | `iban`, `holder`, `country` |
+| `PaylaterInstallment` | `paylater-installment` | `pit` | server | `inquiryId`, `numberOfRates`, `iban`, `country`, `holder` |
+| `PaylaterInvoice` | `paylater-invoice` | `piv` | client | — |
+| `PostFinanceCard` | `post-finance-card` | `pfc` | client | — |
+| `PostFinanceEfinance` | `post-finance-efinance` | `pfe` | client | — |
+| `Prepayment` | `prepayment` | `ppy` | client | — |
+| `Przelewy24` | `przelewy24` | `p24` | client | — |
+| `SepaDirectDebit` | `sepa-direct-debit` | `sdd` | server | `iban`, `bic`, `holder` |
+| `Sofort` | `sofort` | `sft` | client | — (discontinued by Unzer) |
+| `Twint` | `twint` | `twt` | client | — |
+| `Wechatpay` | `wechatpay` | `wcp` | client | — |
+| `Wero` | `wero` | `wro` | server | `walletId` |
+
+## Not implemented, on purpose
+
+**giropay** — discontinued by Unzer, deprecated in their PHP SDK 4.0.0 and no longer
+listed under their payment methods. The short code `gro` still exists in `PaymentTypes`
+so that older payments read back, but there is no class.
+
+**The secured legacy types** — `invoice`, `invoice-secured`, `installment-secured`,
+`sepa-direct-debit-secured`. Deprecated, only relevant for old contracts. Their short
+codes are in `PaymentTypes` for the same reason.
+
+A payment using one of these still reads back: `PaymentType.construct()` builds a
+placeholder class on the fly. The placeholder cannot create a new payment type — asking
+it for its slug raises `NotImplementedError` with an explanation rather than an obscure
+`AttributeError`.
+
+## Method-specific notes
+
+### Installment (`paylater-installment`)
+
+The only method with a mandatory order of calls:
+
+1. `getPaylaterInstallmentPlans(amount, currency, country)` — the plans have to be shown
+   to the customer, because the payment type needs the `inquiryId` from this response.
+2. Create customer and a **v3 basket** (set `totalValueGross`, not `amountTotalGross`).
+3. `createPaymentType(PaylaterInstallment(inquiryId=…, numberOfRates=…))`.
+4. Optionally `riskCheckPaylaterInstallment(request)` — evaluates the customer before the
+   order is placed, so a rejection reaches them during checkout rather than after.
+5. `authorize(request)`.
+
+`expiresAt` in the plans response is a unix timestamp in **milliseconds**, though the API
+reference shows seconds. The `CLIENTIP` header is required for the risk checks — pass
+`client_ip` to the client. Note the API reference calls that header `x-CLIENTIP`; the API
+wants `CLIENTIP`, which is also what the PHP and Java SDKs send.
+
+### Klarna
+
+Runs on a **v1 basket** and without `termsAndConditionUrl`/`privacyPolicyUrl`, both of
+which the documentation lists as mandatory. Verified in production use. Klarna cannot be
+charged directly: authorize first, then charge after the customer returns from the
+redirect (typically on shipment).
+
+### Direct bank transfer (`openbanking-pis`)
+
+Settlement is deferred. After the customer pays, the payment is `completed` while the
+charge stays `pending` — for up to seven working days. Only then does it become `success`,
+or `failed` with `SETTLEMENT_TIMEOUT`. A failed settlement can still recover to `success`
+afterwards. **Do not ship on `charge.pending`.**
+
+Note there are two distinct types: `openbanking-pis` (code `obp`, takes `ibanCountry`) and
+a legacy `pis` (takes `iban`/`bic`/`holder`). Only the former is implemented.
+
+### Cards
+
+3DS is configured per keypair, and `card3ds` on the request can override it. A keypair may
+hold **several configurations for `card`** — one observed account has `MASTER`/`VISA` on
+one channel and `AMEX` on another, with different currencies. Ask for the channel by brand:
+
+```python
+Card(client=client).get_channel_id(brand="AMEX")
+```
+
+Without the brand you get the first entry, which is silently the wrong channel for every
+other brand.
+
+## Where these facts come from
+
+Slugs and short codes are cross-checked against the official SDKs, because the OpenAPI
+spec is incomplete — `clicktopay` and `sofort` are missing from it although both exist:
+
+- `unzerdev/php-sdk`, `src/Resources/PaymentTypes/*.php` — the slug is the kebab-case
+  class short name
+- `unzerdev/java-sdk`, `PaymentTypeEnum.java` — the short codes
+- `unzerdev/integration-core`, `PaymentMethodTypes.php` — the slug list
+
+Everything about actual behaviour is measured against the sandbox. Where a source turned
+out wrong, the docstring in the code says which one was followed.

--- a/examples/01_payment_page.py
+++ b/examples/01_payment_page.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Hosted Payment Page -- the shortest complete flow.
+
+Unzer hosts the page, the customer picks a payment method there, and no card data
+ever reaches your server. Works for every payment method the account has enabled.
+"""
+
+from _common import build_client
+
+from unzer.model import Action, PaymentPage
+
+
+def main() -> None:
+    client = build_client()
+
+    page = client.createPaymentPage(PaymentPage(
+        action=Action.CHARGE,          # or Action.AUTHORIZE to capture later
+        amount=12.34,
+        currency="EUR",
+        returnUrl="https://shop.example.com/return",
+        orderId="example-paypage-1",
+        shopName="Example Shop",
+        shopDescription="A single t-shirt",
+    ))
+
+    print(f"payPageId:   {page.payPageId}")
+    print(f"paymentId:   {page.paymentId}")
+    print(f"redirect to: {page.redirectUrl}")
+
+    # After the customer returns, ask the API what happened. Never decide this from
+    # the return URL alone -- it is under the customer's control.
+    payment = client.getPayment(page.paymentId)
+    print(f"\nstate now:   {payment.state.name}")
+    print(f"charged:     {payment.amountCharged} {payment.currency}")
+    print("A fresh page sits in CREATE until the customer engages with it.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_sepa_direct_debit.py
+++ b/examples/02_sepa_direct_debit.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""Direct charge with SEPA direct debit.
+
+One of the seven methods whose data the SDK sends itself, so no Payment Page and no
+frontend component is involved. The payment type is created at Unzer as part of the
+charge call.
+"""
+
+from _common import build_client, require_method
+
+from unzer.model import PaymentRequest, SepaDirectDebit
+
+# Official sandbox test data: docs.unzer.com/reference/test-data/
+TEST_IBAN = "DE89370400440532013000"
+TEST_BIC = "COBADEFFXXX"
+TEST_HOLDER = "Maximilian Mustermann"
+
+
+def main() -> None:
+    client = build_client()
+    require_method(client, "sepa-direct-debit")
+
+    response = client.charge(PaymentRequest(
+        paymentType=SepaDirectDebit(iban=TEST_IBAN, bic=TEST_BIC, holder=TEST_HOLDER),
+        amount=12.34,
+        currency="EUR",
+        returnUrl="https://shop.example.com/return",
+        orderId="example-sdd-1",
+    ))
+
+    if response.isSuccess:
+        print(f"charged:       {response.transactionId}")
+        print(f"payment:       {response.paymentId}")
+        print(f"short id:      {response.processing.shortId}")
+        print(f"creditor iban: {response.processing.iban}")
+    elif response.isPending:
+        # Not an error: the customer has to confirm somewhere first.
+        print(f"pending, send the customer to: {response.redirectUrl}")
+
+    payment = client.getPayment(response.paymentId)
+    print(f"\nstate:    {payment.state.name}")
+    print(f"charged:  {payment.amountCharged} of {payment.amountTotal}")
+    for transaction in payment.transactions:
+        print(f"  {transaction.action.name:10} {transaction.status.name:8} "
+              f"{transaction.transactionId}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_installment_plans.py
+++ b/examples/03_installment_plans.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""Unzer Installment: fetch the plans, then run the optional risk check.
+
+Order matters here. The plans have to be shown to the customer before anything else,
+because the payment type needs the `inquiryId` of the plan they picked. Installment
+also requires a v3 basket and a customer with an address.
+"""
+
+from _common import build_client, require_method
+
+from unzer.model import (
+    Address,
+    Basket,
+    BasketItem,
+    Customer,
+    ErrorResponse,
+    PaylaterInstallment,
+    PaymentRequest,
+)
+
+AMOUNT = 100.0
+
+
+def main() -> None:
+    client = build_client()
+    require_method(client, "paylater-installment")
+
+    # 1. Which plans does the customer have to choose from?
+    plans = client.getPaylaterInstallmentPlans(
+        amount=AMOUNT, currency="EUR", country="DE", customerType="B2C",
+    )
+    print(f"inquiryId: {plans.inquiryId}")
+    for plan in plans.plans:
+        print(f"  {plan.numberOfRates:2}x  total {plan.totalAmount:>8}  "
+              f"effective {plan.effectiveInterestRate}%")
+    if not plans.plans:
+        print("No plans offered for this amount.")
+        return
+
+    chosen = plans.plans[0]
+
+    # 2. Customer and basket. Installment needs the v3 basket schema, which the
+    #    Basket model selects as soon as totalValueGross is set.
+    customer = client.createOrUpdateCustomer(Customer(
+        firstname="Maximilian", lastname="Mustermann", salutation="mr",
+        birthDate="1980-11-22", email="maximilian.mustermann@example.com",
+        billingAddress=Address(
+            firstname="Maximilian", lastname="Mustermann",
+            street="Hugo-Junkers-Str. 3", zipCode="60386",
+            city="Frankfurt am Main", country="DE",
+        ),
+    ))
+    basket = client.createBasket(Basket(
+        totalValueGross=AMOUNT, currencyCode="EUR", orderId="example-installment-1",
+        basketItems=[BasketItem(
+            title="Custom print t-shirt", quantity=1, vat=19,
+            amountPerUnitGross=AMOUNT, basketItemReferenceId="item-1", type="goods",
+        )],
+    ))
+
+    payment_type = client.createPaymentType(PaylaterInstallment(
+        inquiryId=plans.inquiryId,
+        numberOfRates=chosen.numberOfRates,
+        iban="DE89370400440532013000",
+        holder="Maximilian Mustermann",
+        country="DE",
+    ))
+    print(f"\npayment type: {payment_type.key}")
+
+    request = PaymentRequest(
+        paymentType=payment_type, amount=AMOUNT, currency="EUR",
+        returnUrl="https://shop.example.com/return",
+        customerId=customer.key, basketId=basket.key,
+        orderId="example-installment-1",
+        effectiveInterestRate=chosen.effectiveInterestRate,
+    )
+
+    # 3. Optional: ask before placing the order, so the customer learns about a
+    #    rejection while still in the checkout.
+    try:
+        result = client.riskCheckPaylaterInstallment(request)
+        print(f"risk check passed: {result}")
+    except ErrorResponse as error:
+        print("risk check declined:")
+        for entry in error.errors:
+            print(f"  {entry.code}: {entry.merchantMessage}")
+        return
+
+    print("\nAuthorize next -- left out here so the example does not place an order.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_webhooks.py
+++ b/examples/04_webhooks.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Register, list and delete webhooks.
+
+Unzer notifies you with `{event, publicKey, retrieveUrl, paymentId}` and does **not**
+sign the request. Verify it by checking the source IP against Unzer's allowlist and by
+fetching the resource from `retrieveUrl` yourself -- never trust the notification body.
+"""
+
+from _common import build_client
+
+from unzer.model import Events, Webhook
+
+URL = "https://shop.example.com/unzer/webhook"
+
+
+def main() -> None:
+    client = build_client()
+
+    print("registered webhooks:")
+    for webhook in client.listWebhooks():
+        events = ", ".join(str(event) for event in webhook.event)
+        print(f"  {webhook.webhookId}  {events}  {webhook.url}")
+
+    # One call can register several events; the API answers with one webhook each.
+    created = client.createWebhook(Webhook(url=URL, event=[
+        Events.CHARGE_SUCCEEDED,
+        Events.CHARGE_FAILED,
+        Events.PAYMENT_COMPLETED,
+    ]))
+    print(f"\ncreated {len(created)}:")
+    for webhook in created:
+        events = ", ".join(str(event) for event in webhook.event)
+        print(f"  {webhook.webhookId}  {events}")
+
+    # Only the URL can be changed afterwards -- the event is fixed.
+    first = created[0]
+    first.url = URL + "?v=2"
+    print(f"\nupdated: {client.updateWebhook(first).url}")
+
+    for webhook in created:
+        print(f"deleted: {client.deleteWebhook(webhook)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_client_side_types.py
+++ b/examples/05_client_side_types.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""Paying with a payment type that was created in the browser.
+
+Card, Klarna, PayPal, Apple Pay, Google Pay and others are not created server-side.
+The Payment Page or Unzer's UI components collect the data in the browser, and your
+backend only receives the resulting `typeId` -- which is why those classes carry no
+fields. For cards this is deliberate: taking raw card data would make your integration
+PCI-DSS liable.
+
+Creating such a type server-side produces an empty resource that the provider rejects
+later in the flow, with errors that look like SDK bugs but are not (Klarna answers
+`COR.800.400.160 "Validation error at partner system"`).
+
+So the backend side is short: wrap the id and charge it.
+"""
+
+import sys
+
+from _common import build_client
+
+from unzer.model import Card, Klarna, PaymentRequest, PaymentType
+
+
+def charge_existing_type(client, payment_type: PaymentType, amount: float):
+    """Charge a payment type the frontend already created."""
+    return client.charge(PaymentRequest(
+        paymentType=payment_type,
+        amount=amount,
+        currency="EUR",
+        returnUrl="https://shop.example.com/return",
+        orderId="example-client-side-1",
+    ))
+
+
+def main() -> None:
+    client = build_client()
+
+    type_id = sys.argv[1] if len(sys.argv) > 1 else None
+    if not type_id:
+        print(__doc__)
+        print("Usage: python 05_client_side_types.py <typeId>")
+        print("\nA typeId looks like s-crd-abc123 (card) or s-kla-abc123 (Klarna).")
+        print("Get one from the UI components; there is no server-side shortcut.")
+        return
+
+    # The short code in the id says which class to use -- no need to hardcode it.
+    from unzer.model import PaymentGetResponse
+    method = PaymentGetResponse.getPaymentTypeFromTypeId(type_id)
+    payment_type = PaymentType.construct(method)(type_id)
+    print(f"{type_id} -> {type(payment_type).__name__}")
+
+    response = charge_existing_type(client, payment_type, 12.34)
+    if response.isSuccess:
+        print(f"charged: {response.transactionId}")
+    elif response.isPending:
+        # Card 3DS and Klarna both land here: the customer has to confirm.
+        print(f"pending, redirect the customer to: {response.redirectUrl}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Examples
+
+Runnable scripts, one flow each. They read the credentials from the environment:
+
+```bash
+export UNZER_PRIVATE_KEY=s-priv-...
+export UNZER_PUBLIC_KEY=s-pub-...
+python examples/01_payment_page.py
+```
+
+**Sandbox keys only** (`s-priv-…`). Every script refuses to start with a production key,
+because they all create real transactions on whatever account the key belongs to.
+
+| Script | Flow |
+|---|---|
+| `01_payment_page.py` | hosted Payment Page — works for every payment method |
+| `02_sepa_direct_debit.py` | direct charge, server-side payment type |
+| `03_installment_plans.py` | fetch installment plans and run the risk check |
+| `04_webhooks.py` | register, list and delete webhooks |
+| `05_client_side_types.py` | working with a `typeId` that came from the frontend |
+
+Two things to know before running them.
+
+**Not every account can do everything.** Sandbox accounts differ in which payment methods are
+enabled — `03` needs `paylater-installment`. Each script checks and tells you if the account
+cannot do it. Use `keypair/types` to see what yours has.
+
+**Use the official test data.** Card numbers, IBANs and the logins for redirect flows are
+documented at [docs.unzer.com/reference/test-data](https://docs.unzer.com/reference/test-data/)
+and [test-cards](https://docs.unzer.com/reference/test-cards/). Invented numbers get declined.

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -1,0 +1,46 @@
+"""Shared setup for the examples: credentials from the environment, sandbox only."""
+
+import logging
+import os
+import sys
+
+import unzer
+
+
+def build_client(verbose: bool = False) -> unzer.UnzerClient:
+    """Create a client from ``UNZER_PRIVATE_KEY`` / ``UNZER_PUBLIC_KEY``.
+
+    :param verbose: Log the full requests and responses. Note that this includes
+        IBANs and customer names -- fine for a sandbox, not for production.
+    :return: A client bound to the sandbox.
+    """
+    private_key = os.environ.get("UNZER_PRIVATE_KEY")
+    public_key = os.environ.get("UNZER_PUBLIC_KEY", "")
+    if not private_key:
+        sys.exit("UNZER_PRIVATE_KEY is not set. See examples/README.md.")
+    if not private_key.startswith("s-priv-"):
+        sys.exit(
+            "Refusing to run: UNZER_PRIVATE_KEY is not a sandbox key. Sandbox keys "
+            "start with 's-priv-'. These examples create real transactions."
+        )
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+        logging.getLogger("unzer-sdk").setLevel(logging.DEBUG)
+    return unzer.UnzerClient(private_key, public_key, sandbox=True)
+
+
+def require_method(client: unzer.UnzerClient, slug: str) -> None:
+    """Exit with a readable message if the account has no such payment method.
+
+    Sandbox accounts differ in what is enabled, and the API's error for a missing
+    method is not obvious.
+    """
+    # Compared case-insensitively: the API answers "EPS" while the path is "eps".
+    enabled = {
+        entry["type"].lower()
+        for entry in client.getKeyPairTypes()["paymentTypes"]
+    }
+    if slug.lower() not in enabled:
+        sys.exit(
+            f"This account has no '{slug}'. Enabled: {', '.join(sorted(enabled))}"
+        )


### PR DESCRIPTION
Stacked on #9 — merge #8 and #9 first.

The README was eleven lines: a title, two badges, one sentence. It is also the landing page on
PyPI. It now covers install, authentication, a quickstart, the sandbox, error handling, the
supported payment methods, logging, and — explicitly — what the SDK does *not* do, so
"can it refund?" is answerable without reading `client.py`.

**Every code sample was run against the sandbox.** One of them corrected the text: a fresh
payment sits in `CREATE`, not `PENDING`.

`docs/payment-methods.md` takes the detail that outgrew the README: how a payment type comes
into being, which 7 of the 24 accept server-side data and which 17 are built in the browser,
and the peculiarities per method. It replaces a dated design document that was only ever
git-ignored, and therefore invisible to anyone but its author.

`AGENTS.md` is mostly a warning list, because this API's documentation and its official SDKs
are wrong often enough that neither counts as evidence. Fifteen measured cases back that up.

`examples/` has five scripts, one flow each, all actually executed. The set deliberately skips
card and Klarna: those payment types are created in the browser, so a server-side script cannot
demonstrate them honestly — the fifth script explains that instead. Writing them is what found
the installment timestamp bug in #9, which is the argument for having them.
