### PR TITLE
chore: Add ruff and clear what it finds

### DIFF
--- a/.github/workflows/pep8.yaml
+++ b/.github/workflows/pep8.yaml
@@ -28,7 +28,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -U pycodestyle
+          python -m pip install -U pycodestyle ruff
+
+      # ruff sees what pycodestyle structurally cannot: unused imports,
+      # outdated syntax, implicit Optional, likely bugs. Configured in
+      # pyproject.toml, including the deviations this project makes on purpose.
+      - name: run ruff
+        run: |
+          ruff check --output-format=github .
 
       # The diff check only ever sees the current change. A violation that slips
       # through once is never reported again, so the whole tree is checked too.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,15 @@ drive-by version bumps, no unrelated reformatting.
 ```bash
 uv sync --extra testing          # or: pip install -e ".[testing]"
 uv run pytest                    # unit tests, mocked, no network
+uv run ruff check .              # linting; the config lives in pyproject.toml
 uv run pycodestyle src/ tests/   # the CI checks the full tree, not just the diff
 ```
+
+ruff catches what pycodestyle structurally cannot — unused imports, outdated syntax,
+implicit Optional, likely bugs. Where this project deviates from a rule on purpose, the
+`ignore` list in `pyproject.toml` says which rule and why; add to it with a reason rather
+than sprinkling `# noqa`. And note that a `# noqa` inside a docstring is just prose: it
+does nothing, and one of them hid six over-long lines in this repository for months.
 
 Unit tests mock HTTP with [responses](https://pypi.org/project/responses/) and read their
 payloads from `tests/fixtures/`. **Build fixtures from real captured responses**, never by

--- a/examples/05_client_side_types.py
+++ b/examples/05_client_side_types.py
@@ -18,7 +18,7 @@ import sys
 
 from _common import build_client
 
-from unzer.model import Card, Klarna, PaymentRequest, PaymentType
+from unzer.model import PaymentRequest, PaymentType
 
 
 def charge_existing_type(client, payment_type: PaymentType, amount: float):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,35 @@ markers = [
 [tool.coverage.run]
 branch = true
 source = ["src/unzer"]
+
+[tool.ruff]
+line-length = 120
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E", "W",   # pycodestyle, same as the tox.ini config
+    "F",        # pyflakes: undefined names, unused imports
+    "I",        # import sorting
+    "UP",       # outdated syntax for the supported Python versions
+    "B",        # likely bugs (flake8-bugbear)
+    "C4",       # comprehensions
+    "SIM",      # simplifiable constructs
+    "PIE",      # misc. lint
+    "RET",      # return statements
+    "PTH",      # prefer pathlib over os.path
+    "RUF",      # ruff's own rules
+]
+ignore = [
+    # Deliberate deviations, see AGENTS.md:
+    "N",        # naming — the public API mirrors the camelCase of the Unzer payload
+    "F403",     # `from .model import *` in client.py
+    "F405",     # and the names it brings in
+    "RUF002",   # em dashes and typographic quotes in docstrings are wanted
+    "E226",     # missing whitespace around arithmetic operator, waived since forever
+    "RUF022",   # `__all__` is grouped by module on purpose, not sorted alphabetically
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests import inside functions on purpose, to keep each case readable on its own.
+"tests/*" = ["PLC0415"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ testing = [
 dev = [
     "build",
     "pycodestyle",
+    "ruff",
     "twine>=6",
 ]
 

--- a/src/unzer/__init__.py
+++ b/src/unzer/__init__.py
@@ -5,3 +5,7 @@ __version__ = "1.5.0"
 
 from .client import UnzerClient
 from .model import *
+from .model import __all__ as _model_all
+
+# UnzerClient is the entry point; everything else is re-exported from .model.
+__all__ = ["UnzerClient", *_model_all]

--- a/src/unzer/client.py
+++ b/src/unzer/client.py
@@ -119,9 +119,9 @@ class UnzerClient:
             (e.g. baskets for the Pay later payment methods).
         :return: The json-decoded response from the api.
         """
-        url = "%s/%s/%s" % (self.endpoint, api_version or self.apiVersion, operation)
+        url = f"{self.endpoint}/{api_version or self.apiVersion}/{operation}"
         headers = {
-            "user-agent": "unzer-python-sdk %s" % __version__,
+            "user-agent": f"unzer-python-sdk {__version__}",
             "content-type": "application/json; charset=UTF-8",
             "accept": "application/json",
             "accept-language": self.language,  # language for translation of customerMessage in errors
@@ -228,8 +228,10 @@ class UnzerClient:
 
         .. seealso::
 
-            - https://api.unzer.com/api-reference/index.html#tag/Keypair/operation/getAvailablePaymentMethodTypesWithTypeInformation  # noqa: E501
-            - https://docs.unzer.com/server-side-integration/direct-api-integration/manage-api-resources/api-check-key-configuration/  # noqa: E501
+            - `Keypair: getAvailablePaymentMethodTypesWithTypeInformation
+              <https://api.unzer.com/api-reference/index.html#tag/Keypair/operation/getAvailablePaymentMethodTypesWithTypeInformation>`_
+            - `Check the key configuration
+              <https://docs.unzer.com/server-side-integration/direct-api-integration/manage-api-resources/api-check-key-configuration/>`_
 
         :return: The fetched KeyPairTypesResponse
         """
@@ -245,9 +247,9 @@ class UnzerClient:
         :param errorId: The error id (e.g. p-err-abcdefghij1234567rstuvwyxyz)
         """
         if not isinstance(errorId, str):
-            raise TypeError("Expected a errorId of type str. Got %r" % type(errorId))
+            raise TypeError(f"Expected a errorId of type str. Got {type(errorId)!r}")
         return self.request(
-            "errors/%s" % errorId,
+            f"errors/{errorId}",
             "GET",
         )
 
@@ -260,7 +262,7 @@ class UnzerClient:
         :rtype: Customer
         """
         if not isinstance(customer, Customer):
-            raise TypeError("Expected a Customer object. Got %r" % type(customer))
+            raise TypeError(f"Expected a Customer object. Got {type(customer)!r}")
         if customer.key:
             raise TypeError("Customer has a id (key) set. "
                             "Call updateCustomer to update it or remove it to create a new one.")
@@ -282,11 +284,11 @@ class UnzerClient:
         :rtype: Customer
         """
         if not isinstance(customer, Customer):
-            raise TypeError("Expected a Customer object. Got %r" % type(customer))
+            raise TypeError(f"Expected a Customer object. Got {type(customer)!r}")
         if not customer.keyOrCustomerId:
             raise TypeError("Customer has no customerId oder key (id)")
         data = self.request(
-            "customers/%s" % customer.keyOrCustomerId,
+            f"customers/{customer.keyOrCustomerId}",
             "PUT",
             customer.serialize(),
         )
@@ -317,9 +319,9 @@ class UnzerClient:
         elif isinstance(customer, str):
             codeOrExternalId = customer
         else:
-            raise TypeError("Expected a Customer object or str. Got %r" % type(customer))
+            raise TypeError(f"Expected a Customer object or str. Got {type(customer)!r}")
         data = self.request(
-            "customers/%s" % codeOrExternalId,
+            f"customers/{codeOrExternalId}",
             "DELETE",
         )
         return data["id"]
@@ -333,7 +335,7 @@ class UnzerClient:
         :rtype: Customer
         """
         data = self.request(
-            "customers/%s" % codeOrExternalId,
+            f"customers/{codeOrExternalId}",
             "GET",
         )
         return Customer.fromDict(data)
@@ -347,7 +349,7 @@ class UnzerClient:
         :rtype: Basket
         """
         if not isinstance(basket, Basket):
-            raise TypeError("Expected a Basket object. Got %r" % type(basket))
+            raise TypeError(f"Expected a Basket object. Got {type(basket)!r}")
         data = self.request(
             "baskets",
             "POST",
@@ -366,11 +368,11 @@ class UnzerClient:
         :rtype: Basket
         """
         if not isinstance(basket, Basket):
-            raise TypeError("Expected a Basket object. Got %r" % type(basket))
+            raise TypeError(f"Expected a Basket object. Got {type(basket)!r}")
         if not basket.key:
             raise TypeError("Basket has no key (id)")
         data = self.request(
-            "baskets/%s" % basket.key,
+            f"baskets/{basket.key}",
             "PUT",
             basket.serialize(),
             api_version=basket.apiVersion,
@@ -388,7 +390,7 @@ class UnzerClient:
         :rtype: Basket
         """
         data = self.request(
-            "baskets/%s" % basketId,
+            f"baskets/{basketId}",
             "GET",
             api_version=api_version,
         )
@@ -405,10 +407,10 @@ class UnzerClient:
         :rtype: PaymentType
         """
         if not isinstance(paymentType, PaymentType):
-            raise TypeError("Expected a PaymentType object. Got %r" % type(paymentType))
+            raise TypeError(f"Expected a PaymentType object. Got {type(paymentType)!r}")
         paymentType.validateBeforeRequest()
         data = self.request(
-            "types/%s" % paymentType.method_name.value,
+            f"types/{paymentType.method_name.value}",
             "POST",
             paymentType.serialize(),
         )
@@ -432,7 +434,8 @@ class UnzerClient:
         response is required to create the
         :class:`~unzer.model.PaylaterInstallment` payment type.
 
-        .. seealso:: https://docs.unzer.com/payment-methods/installment/accept-unzer-installment-server-side-only-integration/  # noqa: E501
+        .. seealso:: `Accept Unzer Installment, server-side only
+            <https://docs.unzer.com/payment-methods/installment/accept-unzer-installment-server-side-only-integration/>`_
 
         :param amount: Total amount of the purchase.
         :param currency: ISO currency code of the transaction (``EUR`` or ``CHF``).
@@ -459,7 +462,7 @@ class UnzerClient:
             if value is not None:
                 query[key] = value
         data = self.request(
-            "types/%s/plans?%s" % (PaylaterInstallment.method_name.value, urlencode(query)),
+            f"types/{PaylaterInstallment.method_name.value}/plans?{urlencode(query)}",
             "GET",
         )
         return InstallmentPlans.fromDict(data)
@@ -484,7 +487,8 @@ class UnzerClient:
             but implemented in neither the PHP nor the Java SDK,
             so the payload could only be taken from the documentation.
 
-        .. seealso:: https://docs.unzer.com/payment-methods/installment/accept-unzer-installment-server-side-only-integration/  # noqa: E501
+        .. seealso:: `Accept Unzer Installment, server-side only
+            <https://docs.unzer.com/payment-methods/installment/accept-unzer-installment-server-side-only-integration/>`_
 
         :param payment: The PaymentRequest model of the intended payment.
         :param client_ip: (optional) IP address of the customer,
@@ -494,12 +498,12 @@ class UnzerClient:
         :raises ErrorResponse: If the risk check was declined.
         """
         if not isinstance(payment, PaymentRequest):
-            raise TypeError("Expected a PaymentRequest object. Got %r" % type(payment))
+            raise TypeError(f"Expected a PaymentRequest object. Got {type(payment)!r}")
         if not payment.paymentType or not payment.paymentType.key:
             raise ValueError("The paymentType must be created before the risk check")
         payment.validateBeforeRequest()
         data = self.request(
-            "types/%s/risk-check" % PaylaterInstallment.method_name.value,
+            f"types/{PaylaterInstallment.method_name.value}/risk-check",
             "POST",
             payment.serialize(),
             additional_headers={"CLIENTIP": client_ip} if client_ip else None,
@@ -517,7 +521,7 @@ class UnzerClient:
         :rtype: PaymentPageResponse
         """
         if not isinstance(paymentPage, PaymentPage) or isinstance(paymentPage, PaymentPageResponse):
-            raise TypeError("Expected a PaymentPage object. Got %r" % type(paymentPage))
+            raise TypeError(f"Expected a PaymentPage object. Got {type(paymentPage)!r}")
         paymentPage.validateBeforeRequest()
         data = self.request(
             f"paypage/{paymentPage.action.value}",
@@ -535,9 +539,9 @@ class UnzerClient:
         :rtype: PaymentPageResponse
         """
         if not isinstance(payPageId, str):
-            raise TypeError("Expected a payPageId of type str. Got %r" % type(payPageId))
+            raise TypeError(f"Expected a payPageId of type str. Got {type(payPageId)!r}")
         data = self.request(
-            "paypage/%s" % payPageId,
+            f"paypage/{payPageId}",
             "GET",
         )
         return PaymentPageResponse.fromDict(data)
@@ -551,9 +555,9 @@ class UnzerClient:
         :rtype: PaymentGetResponse
         """
         if not isinstance(codeOrOrderId, str):
-            raise TypeError("Expected a codeOrOrderId of type str. Got %r" % type(codeOrOrderId))
+            raise TypeError(f"Expected a codeOrOrderId of type str. Got {type(codeOrOrderId)!r}")
         data = self.request(
-            "payments/%s" % codeOrOrderId,
+            f"payments/{codeOrOrderId}",
             "GET",
         )
         return PaymentGetResponse.fromDict(data, self)
@@ -593,9 +597,9 @@ class UnzerClient:
         """Internal helper for authorize and charge calls
         """
         if type_ not in {"authorize", "charges"}:
-            raise ValueError("Invalid type %r" % type_)
+            raise ValueError(f"Invalid type {type_!r}")
         if not isinstance(payment, PaymentRequest):
-            raise TypeError("Expected a PaymentRequest object. Got %r" % type(PaymentRequest))
+            raise TypeError(f"Expected a PaymentRequest object. Got {type(PaymentRequest)!r}")
         if not payment.paymentType:
             raise ValueError("No paymentType set")
         if not payment.paymentType.key:
@@ -624,11 +628,11 @@ class UnzerClient:
         :rtype: PaymentResponse
         """
         if not isinstance(codeOrOrderId, str):
-            raise TypeError("Expected a codeOrOrderId of type str. Got %r" % type(codeOrOrderId))
+            raise TypeError(f"Expected a codeOrOrderId of type str. Got {type(codeOrOrderId)!r}")
         if not isinstance(txnCode, (str, NoneType)):
-            raise TypeError("Expected a txnCode of type str or None. Got %r" % type(txnCode))
+            raise TypeError(f"Expected a txnCode of type str or None. Got {type(txnCode)!r}")
         data = self.request(
-            "payments/%s/charges/%s" % (codeOrOrderId, txnCode or ""),
+            "payments/{}/charges/{}".format(codeOrOrderId, txnCode or ""),
             "GET",
         )
         return PaymentResponse.fromDict(data, self)
@@ -654,7 +658,7 @@ class UnzerClient:
         :rtype: Webhook
         """
         data = self.request(
-            "webhooks/%s" % webhookId,
+            f"webhooks/{webhookId}",
             "GET",
         )
         return Webhook.fromDict(data)
@@ -667,7 +671,7 @@ class UnzerClient:
         :rtype: list[Webhook]
         """
         if not isinstance(webhook, Webhook):
-            raise TypeError("Expected a Webhook object. Got %r" % type(webhook))
+            raise TypeError(f"Expected a Webhook object. Got {type(webhook)!r}")
         if webhook.webhookId:
             raise TypeError("Webhook has a id set. "
                             "Call updateWebhook to update it or remove the id to create a new one.")
@@ -689,13 +693,13 @@ class UnzerClient:
         :rtype: Webhook
         """
         if not isinstance(webhook, Webhook):
-            raise TypeError("Expected a Webhook object. Got %r" % type(webhook))
+            raise TypeError(f"Expected a Webhook object. Got {type(webhook)!r}")
         if not webhook.webhookId:
             raise ValueError("Webhook to update has no id")
         if not webhook.url:
             raise ValueError("Webhook to update has no url")
         data = self.request(
-            "webhooks/%s" % webhook.webhookId,
+            f"webhooks/{webhook.webhookId}",
             "PUT",
             {"url": webhook.url},
         )
@@ -709,10 +713,9 @@ class UnzerClient:
         :return: A list of Webhooks
         :rtype: list[Webhook]
         """
-        if "events" not in data:
-            webhooks = [data]  # got exactly one webhook, data is the webhook itself
-        else:
-            webhooks = data["events"]  # list of webhooks wrapped in events property
+        # A single webhook comes back as the object itself, several are wrapped
+        # in an `events` property.
+        webhooks = data.get("events", [data])
         return [Webhook.fromDict(webhook) for webhook in webhooks]
 
     def deleteWebhook(self, webhookOrId):
@@ -726,7 +729,7 @@ class UnzerClient:
         if isinstance(webhookOrId, Webhook):
             webhookOrId = webhookOrId.webhookId
         data = self.request(
-            "webhooks/%s" % webhookOrId,
+            f"webhooks/{webhookOrId}",
             "DELETE",
         )
         return data["id"]

--- a/src/unzer/client.py
+++ b/src/unzer/client.py
@@ -86,7 +86,7 @@ class UnzerClient:
         :param timeout: (optional) Timeout in seconds of a single request,
             overrides :attr:`timeout`.
         """
-        super(UnzerClient, self).__init__()
+        super().__init__()
         self.private_key = private_key
         self.public_key = public_key
         self.sandbox = sandbox
@@ -182,19 +182,18 @@ class UnzerClient:
             if 200 <= r.status_code <= 201:
                 logger.debug("Response[%s %s]: %r", r.status_code, r.reason, r.json())
                 return r.json()
-            elif 500 <= r.status_code < 600:
+            if 500 <= r.status_code < 600:
                 logger.debug("Server error")
                 logger.debug("Response[%s %s]: %r", r.status_code, r.reason, r.text)
                 if not retryable:
                     break
                 continue
-            else:
-                logger.debug("Client error")
-                logger.debug("Response[%s %s]: %r", r.status_code, r.reason, r.text)
-                errorResponse = ErrorResponse.fromDict(r.json())
-                errorResponse.statusCode = r.status_code
-                errorResponse.srcResponse = r
-                raise errorResponse
+            logger.debug("Client error")
+            logger.debug("Response[%s %s]: %r", r.status_code, r.reason, r.text)
+            errorResponse = ErrorResponse.fromDict(r.json())
+            errorResponse.statusCode = r.status_code
+            errorResponse.srcResponse = r
+            raise errorResponse
 
         logger.error("All request attempts failed")
         if r is not None:

--- a/src/unzer/client.py
+++ b/src/unzer/client.py
@@ -61,8 +61,8 @@ class UnzerClient:
             public_key: str,
             sandbox: bool = False,
             language: str = "en",
-            client_ip: str = None,
-            timeout: int = None,
+            client_ip: str | None = None,
+            timeout: int | None = None,
     ):
         """Create a new client for the unzer-api.
 
@@ -100,8 +100,8 @@ class UnzerClient:
             operation: str,
             method: HttpMethod,
             payload: t.Any = None,
-            additional_headers: dict[str, str] = None,
-            api_version: str = None,
+            additional_headers: dict[str, str] | None = None,
+            api_version: str | None = None,
     ) -> t.Any:
         """Perform a request to the unzer-api.
 
@@ -377,7 +377,7 @@ class UnzerClient:
         )
         return self.getBasket(data["id"], api_version=basket.apiVersion)
 
-    def getBasket(self, basketId, api_version: str = None):
+    def getBasket(self, basketId, api_version: str | None = None):
         """Fetch a basket.
 
         :param basketId: basket's id (key)
@@ -419,11 +419,11 @@ class UnzerClient:
             amount: float,
             currency: str,
             country: str,
-            customerType: str = None,
-            orderId: str = None,
-            startDateOfPurchase: str = None,
-            endDateOfPurchase: str = None,
-            nominalInterest: str = None,
+            customerType: str | None = None,
+            orderId: str | None = None,
+            startDateOfPurchase: str | None = None,
+            endDateOfPurchase: str | None = None,
+            nominalInterest: str | None = None,
     ) -> InstallmentPlans:
         """Fetch the available installment plans for a purchase.
 
@@ -467,7 +467,7 @@ class UnzerClient:
     def riskCheckPaylaterInstallment(
             self,
             payment: PaymentRequest,
-            client_ip: str = None,
+            client_ip: str | None = None,
     ) -> RiskCheckResponse:
         """Perform a risk check for an installment payment.
 
@@ -588,7 +588,7 @@ class UnzerClient:
             self,
             type_: str,
             payment: PaymentRequest,
-            headers: dict[str, str] = None,
+            headers: dict[str, str] | None = None,
     ) -> PaymentResponse:
         """Internal helper for authorize and charge calls
         """

--- a/src/unzer/model/additional_transaction_data.py
+++ b/src/unzer/model/additional_transaction_data.py
@@ -36,12 +36,11 @@ class CardTransactionData(BaseModel):
         self.exemptionType = exemptionType
 
     def serialize(self) -> dict[str, JSONValue]:
-        data = {
+        return {
             "recurrenceType": self.recurrenceType,
             "liability": self.liability,
             "exemptionType": self.exemptionType,
         }
-        return data
 
     @classmethod
     def fromDict(cls, data: dict[str, JSONValue]) -> t.Self:
@@ -69,12 +68,11 @@ class ShippingTransactionData(BaseModel):
         self.returnTrackingId = returnTrackingId
 
     def serialize(self) -> dict[str, JSONValue]:
-        data = {
+        return {
             "deliveryTrackingId": self.deliveryTrackingId,
             "deliveryService": self.deliveryService,
             "returnTrackingId": self.returnTrackingId,
         }
-        return data
 
     @classmethod
     def fromDict(cls, data: dict[str, JSONValue]) -> t.Self:
@@ -139,7 +137,7 @@ class RiskData(BaseModel):
         self.confirmedAmount = confirmedAmount
 
     def serialize(self) -> dict[str, JSONValue]:
-        data = {
+        return {
             "threatMetrixId": self.threatMetrixId,
             "registrationLevel": self.registrationLevel.value if self.registrationLevel is not None else None,
             "registrationDate": (self.registrationDate.strftime("%Y%m%d")
@@ -149,7 +147,6 @@ class RiskData(BaseModel):
             "confirmedOrders": self.confirmedOrders,
             "confirmedAmount": self.confirmedAmount,
         }
-        return data
 
     @classmethod
     def fromDict(cls, data: dict[str, JSONValue]) -> t.Self:
@@ -172,10 +169,9 @@ class PaypalData(BaseModel):
         self.checkoutType = checkoutType
 
     def serialize(self) -> dict[str, JSONValue]:
-        data = {
+        return {
             "checkoutType": self.checkoutType,
         }
-        return data
 
     @classmethod
     def fromDict(cls, data: dict[str, JSONValue]) -> t.Self:
@@ -211,13 +207,12 @@ class AdditionalTransactionData(BaseModel):
         self.paypal = paypal
 
     def serialize(self) -> dict[str, JSONValue]:
-        data = {
+        return {
             "card": self.card.serialize() if self.card else None,
             "shipping": self.shipping.serialize() if self.shipping else None,
             "riskData": self.risk_data.serialize() if self.risk_data else None,
             "paypal": self.paypal.serialize() if self.paypal else None,
         }
-        return data
 
     @classmethod
     def fromDict(cls, data: dict[str, JSONValue]) -> t.Self:

--- a/src/unzer/model/additional_transaction_data.py
+++ b/src/unzer/model/additional_transaction_data.py
@@ -12,9 +12,9 @@ logger = logging.getLogger("unzer-sdk").getChild(__name__)
 class CardTransactionData(BaseModel):
     def __init__(
             self,
-            recurrenceType: t.Literal["scheduled", "unscheduled", "oneclick"] = None,
-            liability: t.Literal["merchant", "issuer"] = None,
-            exemptionType: str = None,
+            recurrenceType: t.Literal["scheduled", "unscheduled", "oneclick"] | None = None,
+            liability: t.Literal["merchant", "issuer"] | None = None,
+            exemptionType: str | None = None,
             **kwargs,
     ):
         """
@@ -51,9 +51,9 @@ class CardTransactionData(BaseModel):
 class ShippingTransactionData(BaseModel):
     def __init__(
             self,
-            deliveryTrackingId: str = None,
-            deliveryService: str = None,
-            returnTrackingId: str = None,
+            deliveryTrackingId: str | None = None,
+            deliveryService: str | None = None,
+            returnTrackingId: str | None = None,
             **kwargs,
     ):
         """
@@ -109,13 +109,13 @@ class RegistrationLevel(enum.IntEnum):
 class RiskData(BaseModel):
     def __init__(
             self,
-            confirmedAmount: float = None,
-            confirmedOrders: int = None,
+            confirmedAmount: float | None = None,
+            confirmedOrders: int | None = None,
             customerGroup: CustomerGroup = None,
-            customerId: str = None,
-            registrationDate: dt | date = None,
+            customerId: str | None = None,
+            registrationDate: dt | date | None = None,
             registrationLevel: RegistrationLevel = None,
-            threatMetrixId: str = None,
+            threatMetrixId: str | None = None,
             **kwargs
     ):
         """
@@ -159,7 +159,7 @@ class RiskData(BaseModel):
 class PaypalData(BaseModel):
     def __init__(
             self,
-            checkoutType: t.Literal["EXPRESS"] = None,
+            checkoutType: t.Literal["EXPRESS"] | None = None,
             **kwargs
     ):
         """

--- a/src/unzer/model/additional_transaction_data.py
+++ b/src/unzer/model/additional_transaction_data.py
@@ -1,7 +1,8 @@
 import enum
 import logging
 import typing as t
-from datetime import date, datetime as dt
+from datetime import date
+from datetime import datetime as dt
 
 from unzer.model.base import BaseModel, JSONValue
 

--- a/src/unzer/model/address.py
+++ b/src/unzer/model/address.py
@@ -41,10 +41,7 @@ class Address(BaseModel):
 
     @property
     def name(self):
-        return "%s %s" % (
-            self.getString(self.firstname),
-            self.getString(self.lastname),
-        )
+        return f"{self.getString(self.firstname)} {self.getString(self.lastname)}"
 
     @name.setter
     def name(self, name):

--- a/src/unzer/model/base.py
+++ b/src/unzer/model/base.py
@@ -1,9 +1,8 @@
 import abc
-
 import typing as t
 
 if t.TYPE_CHECKING:
-    from ..client import UnzerClient  # noqa # pylint: disable=unused-import
+    from ..client import UnzerClient  # pylint: disable=unused-import
 
 JSONValue: t.TypeAlias = str | int | float | bool | list["JSONValue"] | dict[str, "JSONValue"] | None
 
@@ -22,7 +21,7 @@ class BaseModel(abc.ABC):
         :param client: (optional) The client instance.
         """
         super().__init__()
-        self._client: "UnzerClient" = client
+        self._client: UnzerClient = client
 
     def getString(self, value):
         if value is None:
@@ -32,13 +31,11 @@ class BaseModel(abc.ABC):
     @abc.abstractmethod
     def serialize(self) -> dict[str, JSONValue]:
         """Serialize data from an object as dict for the request-payload."""
-        pass
 
     @classmethod
     @abc.abstractmethod
     def fromDict(cls, data: dict[str, JSONValue]) -> t.Self:
         """Unserialize data from a dict from a response to new object"""
-        pass
 
     def validateBeforeRequest(self) -> bool:
         """Validate the model.

--- a/src/unzer/model/base.py
+++ b/src/unzer/model/base.py
@@ -10,7 +10,7 @@ JSONValue: t.TypeAlias = str | int | float | bool | list["JSONValue"] | dict[str
 class BaseModel(abc.ABC):
     EMPTY_STRING = ""
 
-    REQUIRED_ATTRIBUTES = []
+    REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = []
 
     def __init__(
             self,
@@ -46,14 +46,14 @@ class BaseModel(abc.ABC):
         """
         for attr in type(self).REQUIRED_ATTRIBUTES:  # use always the cls-attributes
             if not getattr(self, attr):
-                raise ValueError("%s misses the attribute *%s*." % (type(self).__name__, attr))
+                raise ValueError(f"{type(self).__name__} misses the attribute *{attr}*.")
         return True
 
     def __repr__(self) -> str:
-        return "%s.%s(%s)" % (
+        return "{}.{}({})".format(
             self.__class__.__module__,
             self.__class__.__name__,
-            ", ".join("%s=%r" % (k, v) for k, v in sorted(self))
+            ", ".join(f"{k}={v!r}" for k, v in sorted(self))
         )
 
     def asDict(self) -> dict[str, t.Any]:
@@ -71,5 +71,4 @@ class BaseModel(abc.ABC):
 
     def __iter__(self):
         """Yield the attributes of the model"""
-        for k, v in self.asDict().items():
-            yield k, v
+        yield from self.asDict().items()

--- a/src/unzer/model/basket.py
+++ b/src/unzer/model/basket.py
@@ -1,8 +1,8 @@
 import typing as t
 
+from ..utils import parseFloat, roundAmount
 from .base import BaseModel, JSONValue
 from .basketItem import BasketItem
-from ..utils import parseFloat, roundAmount
 
 
 class Basket(BaseModel):

--- a/src/unzer/model/basketItem.py
+++ b/src/unzer/model/basketItem.py
@@ -1,7 +1,7 @@
 import typing as t
 
-from .base import BaseModel, JSONValue
 from ..utils import parseFloat
+from .base import BaseModel, JSONValue
 
 
 class BasketItem(BaseModel):

--- a/src/unzer/model/customer.py
+++ b/src/unzer/model/customer.py
@@ -99,7 +99,7 @@ class Customer(BaseModel):
         if not value:
             value = Salutation.UNKNOWN
         elif value not in {Salutation.MR, Salutation.MRS, Salutation.UNKNOWN}:
-            raise TypeError("Invalid salutation %r" % value)
+            raise TypeError(f"Invalid salutation {value!r}")
         self._salutation = value
 
     @property
@@ -116,9 +116,9 @@ class Customer(BaseModel):
             elif "." in value:  # European Date
                 value = datetime.datetime.strptime(value, "%d.%m.%Y")
             else:
-                raise TypeError("Invalid date format of %r" % value)
+                raise TypeError(f"Invalid date format of {value!r}")
         elif not isinstance(value, (datetime.datetime, datetime.date)):
-            raise TypeError("Invalid value %r" % value)
+            raise TypeError(f"Invalid value {value!r}")
         self._birthDate = value
 
     @property

--- a/src/unzer/model/error.py
+++ b/src/unzer/model/error.py
@@ -1,8 +1,6 @@
 import datetime
 import logging
 
-import requests
-
 logger = logging.getLogger("unzer-sdk").getChild(__name__)
 
 
@@ -44,7 +42,7 @@ class ErrorResponse(Exception):
             **kwargs
 
     ):
-        super(ErrorResponse, self).__init__(message)
+        super().__init__(message)
         if errors is None:
             errors = []
         self.timestamp = timestamp  # type: str

--- a/src/unzer/model/error.py
+++ b/src/unzer/model/error.py
@@ -13,15 +13,13 @@ class Error:
             logger.warning("Error got additional unhandled data: %r", kwargs)
 
     def __str__(self):
-        return "%s %s: %s" % (self.__class__.__name__, self.code, self.merchantMessage)
+        return f"{self.__class__.__name__} {self.code}: {self.merchantMessage}"
 
     def __repr__(self):
-        return "%s.%s(code=%r, merchantMessage=%r, customerMessage=%r)" % (
-            self.__class__.__module__,
-            self.__class__.__name__,
-            self.code,
-            self.merchantMessage,
-            self.customerMessage,
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"code={self.code!r}, merchantMessage={self.merchantMessage!r}, "
+            f"customerMessage={self.customerMessage!r})"
         )
 
 
@@ -73,11 +71,8 @@ class ErrorResponse(Exception):
         )
 
     def __repr__(self):
-        return "%s.%s(url=%r, errorId=%r, traceId=%r, errors=%r)" % (
-            self.__class__.__module__,
-            self.__class__.__name__,
-            self.url,
-            self.errorId,
-            self.traceId,
-            self.errors,
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"url={self.url!r}, errorId={self.errorId!r}, "
+            f"traceId={self.traceId!r}, errors={self.errors!r})"
         )

--- a/src/unzer/model/installment_plans.py
+++ b/src/unzer/model/installment_plans.py
@@ -1,8 +1,8 @@
 import datetime
 import typing as t
 
-from .base import BaseModel, JSONValue
 from ..utils import parseBool, parseDate, parseFloat, parseTimestamp
+from .base import BaseModel, JSONValue
 
 
 class InstallmentRate(BaseModel):

--- a/src/unzer/model/installment_plans.py
+++ b/src/unzer/model/installment_plans.py
@@ -10,8 +10,8 @@ class InstallmentRate(BaseModel):
 
     def __init__(
             self,
-            date: datetime.date = None,
-            rate: float = None,
+            date: datetime.date | None = None,
+            rate: float | None = None,
             **kwargs,
     ):
         """Create a new InstallmentRate.
@@ -39,14 +39,14 @@ class InstallmentPlan(BaseModel):
 
     def __init__(
             self,
-            numberOfRates: int = None,
-            totalAmount: float = None,
-            nominalInterestRate: float = None,
-            effectiveInterestRate: float = None,
-            interestAmount: float = None,
-            minimumInstallmentFee: float = None,
-            secciUrl: str = None,
-            installmentRates: list[InstallmentRate] = None,
+            numberOfRates: int | None = None,
+            totalAmount: float | None = None,
+            nominalInterestRate: float | None = None,
+            effectiveInterestRate: float | None = None,
+            interestAmount: float | None = None,
+            minimumInstallmentFee: float | None = None,
+            secciUrl: str | None = None,
+            installmentRates: list[InstallmentRate] | None = None,
             **kwargs,
     ):
         """Create a new InstallmentPlan.
@@ -106,15 +106,15 @@ class InstallmentPlans(BaseModel):
 
     def __init__(
             self,
-            inquiryId: str = None,
-            amount: float = None,
-            currency: str = None,
-            expiresAt: datetime.datetime = None,
-            plans: list[InstallmentPlan] = None,
-            isSuccess: bool = None,
-            isPending: bool = None,
-            isResumed: bool = None,
-            isError: bool = None,
+            inquiryId: str | None = None,
+            amount: float | None = None,
+            currency: str | None = None,
+            expiresAt: datetime.datetime | None = None,
+            plans: list[InstallmentPlan] | None = None,
+            isSuccess: bool | None = None,
+            isPending: bool | None = None,
+            isResumed: bool | None = None,
+            isError: bool | None = None,
             **kwargs,
     ):
         """Create a new InstallmentPlans.

--- a/src/unzer/model/payment.py
+++ b/src/unzer/model/payment.py
@@ -69,7 +69,8 @@ class PaymentTypes(enum.Enum):
 
     Used as short-name in type-ids like ``s-crd-abc456def789``
 
-    .. seealso:: https://github.com/unzerdev/java-sdk/blob/main/src/main/java/com/unzer/payment/paymenttypes/PaymentTypeEnum.java  # noqa: E501
+    .. seealso:: `PaymentTypeEnum.java
+        <https://github.com/unzerdev/java-sdk/blob/main/src/main/java/com/unzer/payment/paymenttypes/PaymentTypeEnum.java>`_
 
     The official SDKs disagree on the exact set, so both were compared. Three
     deliberate differences:
@@ -135,7 +136,8 @@ class PaymentMethodTypes(enum.Enum):
 
     Used as name in URLs like ``types/<name>/``
 
-    .. seealso:: https://github.com/unzerdev/integration-core/blob/master/src/BusinessLogic/Domain/PaymentMethod/Enums/PaymentMethodTypes.php  # noqa: E501
+    .. seealso:: `PaymentMethodTypes.php
+        <https://github.com/unzerdev/integration-core/blob/master/src/BusinessLogic/Domain/PaymentMethod/Enums/PaymentMethodTypes.php>`_
     """
     ALI_PAY = "alipay"
     APPLE_PAY = "applepay"
@@ -254,7 +256,7 @@ class PaymentGetResponse(BaseModel):
         # if state not in vars(PaymentState).values():
         #     raise TypeError("Invalid state %r" % state)
         if not isinstance(card3ds, (bool, NoneType)):
-            raise TypeError("Invalid value %r for card3ds. Must be a boolean or None." % card3ds)
+            raise TypeError(f"Invalid value {card3ds!r} for card3ds. Must be a boolean or None.")
         self.paymentId = paymentId  # type:str
         self.paymentType = paymentType  # type:PaymentTypes
         self.state = state  # type:PaymentState
@@ -426,7 +428,7 @@ class PaymentTransaction(BaseModel):
 
 
 class PaymentRequest(BaseModel):
-    REQUIRED_ATTRIBUTES = ["paymentType"]
+    REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = ["paymentType"]
 
     def __init__(
             self,
@@ -486,7 +488,7 @@ class PaymentRequest(BaseModel):
         """
         super().__init__(**kwargs)
         if not isinstance(card3ds, (bool, NoneType)):
-            raise TypeError("Invalid value %r for card3ds. Must be a boolean or None." % card3ds)
+            raise TypeError(f"Invalid value {card3ds!r} for card3ds. Must be a boolean or None.")
         self.paymentType = paymentType  # type:PaymentType
         self.paymentId = paymentId  # type:str
         self.amount = amount  # type:float
@@ -780,8 +782,9 @@ class PaymentResponseMetadata(BaseModel):
     def fromDict(cls, data):
         data = data.copy()
         # Nobody, really nobody starts identifier with a digit. Unzer: here you have the 3dsEci flag
-        data["threeDsEci"] = data["3dsEci"] if "3dsEci" in data else None
+        data["threeDsEci"] = data.get("3dsEci")
         return cls(**data)
 
 
-from unzer.model.payment_type.abstract_paymenttype import PaymentType  # noqa: Avoid circular imports
+# Imported at the end of the module to avoid a circular import.
+from unzer.model.payment_type.abstract_paymenttype import PaymentType  # noqa: E402

--- a/src/unzer/model/payment.py
+++ b/src/unzer/model/payment.py
@@ -1,13 +1,12 @@
-import datetime
 import enum
 import logging
 import re
 import typing as t
 from types import NoneType
 
+from ..utils import parseBool, parseDateTime, roundAmount
 from .additional_transaction_data import AdditionalTransactionData
 from .base import BaseModel
-from ..utils import parseBool, parseDateTime, roundAmount
 
 if t.TYPE_CHECKING:
     from ..client import UnzerClient

--- a/src/unzer/model/payment_type/abstract_paymenttype.py
+++ b/src/unzer/model/payment_type/abstract_paymenttype.py
@@ -87,7 +87,11 @@ class PaymentType(BaseModel):
 
     def get_configuration(self) -> dict:
         if self._client is None:
-            raise OSError(f"PaymentType {type(self).__name__} was not initialized with client instance")
+            raise RuntimeError(
+                f"{type(self).__name__} was created without a client, so it cannot "
+                f"read its keypair configuration. Pass client= to the constructor, "
+                f"or use the instance the client returned."
+            )
         configurations = self.get_configurations()
         if len(configurations) > 1:
             logger.warning(
@@ -107,7 +111,11 @@ class PaymentType(BaseModel):
         :raises LookupError: If the payment type is not configured at all.
         """
         if self._client is None:
-            raise OSError(f"PaymentType {type(self).__name__} was not initialized with client instance")
+            raise RuntimeError(
+                f"{type(self).__name__} was created without a client, so it cannot "
+                f"read its keypair configuration. Pass client= to the constructor, "
+                f"or use the instance the client returned."
+            )
         key_pair_types = self._client.getKeyPairTypes()
         logger.debug(f"key_pair_types: {key_pair_types!r}")
         # Compared case-insensitive: Unzer is not consistent about the casing of the

--- a/src/unzer/model/payment_type/abstract_paymenttype.py
+++ b/src/unzer/model/payment_type/abstract_paymenttype.py
@@ -35,13 +35,11 @@ class PaymentType(BaseModel):
     @abc.abstractmethod
     def method(self) -> "PaymentTypes":
         """Hold the type."""
-        pass
 
     @property
     @abc.abstractmethod
     def method_name(self) -> "PaymentMethodTypes":
         """Hold the full payment name."""
-        pass
 
     # TODO: Rename method and method_name (Unzer himself has no clear concept or consistent naming for this either)
 
@@ -73,7 +71,7 @@ class PaymentType(BaseModel):
             yield subclass
 
     @classmethod
-    def construct(cls, method: "PaymentTypes") -> t.Type["PaymentType"]:
+    def construct(cls, method: "PaymentTypes") -> type["PaymentType"]:
         for subclass in PaymentType.get_subclasses():
             if subclass.method == method:
                 return subclass
@@ -89,7 +87,7 @@ class PaymentType(BaseModel):
 
     def get_configuration(self) -> dict:
         if self._client is None:
-            raise IOError(f"PaymentType {type(self).__name__} was not initialized with client instance")
+            raise OSError(f"PaymentType {type(self).__name__} was not initialized with client instance")
         configurations = self.get_configurations()
         if len(configurations) > 1:
             logger.warning(
@@ -109,7 +107,7 @@ class PaymentType(BaseModel):
         :raises LookupError: If the payment type is not configured at all.
         """
         if self._client is None:
-            raise IOError(f"PaymentType {type(self).__name__} was not initialized with client instance")
+            raise OSError(f"PaymentType {type(self).__name__} was not initialized with client instance")
         key_pair_types = self._client.getKeyPairTypes()
         logger.debug(f"key_pair_types: {key_pair_types!r}")
         # Compared case-insensitive: Unzer is not consistent about the casing of the

--- a/src/unzer/model/payment_type/abstract_paymenttype.py
+++ b/src/unzer/model/payment_type/abstract_paymenttype.py
@@ -45,7 +45,7 @@ class PaymentType(BaseModel):
 
     def __init__(
             self,
-            key: str = None,
+            key: str | None = None,
             **kwargs
     ):
         """Create a new paymentType ressource.

--- a/src/unzer/model/payment_type/alipay.py
+++ b/src/unzer/model/payment_type/alipay.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/applepay.py
+++ b/src/unzer/model/payment_type/applepay.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/bancontact.py
+++ b/src/unzer/model/payment_type/bancontact.py
@@ -9,7 +9,7 @@ class Bancontact(PaymentType):
     method = PaymentTypes.BANCONTACT
     method_name = PaymentMethodTypes.BANCONTACT
 
-    REQUIRED_ATTRIBUTES = ["holder"]
+    REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = ["holder"]
 
     def __init__(
             self,

--- a/src/unzer/model/payment_type/bancontact.py
+++ b/src/unzer/model/payment_type/bancontact.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/card.py
+++ b/src/unzer/model/payment_type/card.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/clicktopay.py
+++ b/src/unzer/model/payment_type/clicktopay.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/eps.py
+++ b/src/unzer/model/payment_type/eps.py
@@ -2,6 +2,7 @@ import typing as t
 
 from unzer.model.base import JSONValue
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/eps.py
+++ b/src/unzer/model/payment_type/eps.py
@@ -17,8 +17,8 @@ class Eps(PaymentType):
 
     def __init__(
             self,
-            key: str = None,
-            bic: str = None,
+            key: str | None = None,
+            bic: str | None = None,
             **kwargs,
     ):
         """Create a new EPS paymentType resource.

--- a/src/unzer/model/payment_type/googlepay.py
+++ b/src/unzer/model/payment_type/googlepay.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/ideal.py
+++ b/src/unzer/model/payment_type/ideal.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/klarna.py
+++ b/src/unzer/model/payment_type/klarna.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/openbanking_pis.py
+++ b/src/unzer/model/payment_type/openbanking_pis.py
@@ -26,8 +26,8 @@ class OpenbankingPis(PaymentType):
 
     def __init__(
             self,
-            key: str = None,
-            ibanCountry: str = None,
+            key: str | None = None,
+            ibanCountry: str | None = None,
             **kwargs,
     ):
         """Create a new Direct Bank Transfer paymentType resource.

--- a/src/unzer/model/payment_type/openbanking_pis.py
+++ b/src/unzer/model/payment_type/openbanking_pis.py
@@ -2,6 +2,7 @@ import typing as t
 
 from unzer.model.base import JSONValue
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/paylater_direct_debit.py
+++ b/src/unzer/model/payment_type/paylater_direct_debit.py
@@ -17,7 +17,7 @@ class PaylaterDirectDebit(PaymentType):
     method = PaymentTypes.PAYLATER_DIRECT_DEBIT
     method_name = PaymentMethodTypes.DIRECT_DEBIT_SECURED
 
-    REQUIRED_ATTRIBUTES = ["iban", "holder"]
+    REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = ["iban", "holder"]
 
     def __init__(
             self,

--- a/src/unzer/model/payment_type/paylater_direct_debit.py
+++ b/src/unzer/model/payment_type/paylater_direct_debit.py
@@ -2,6 +2,7 @@ import typing as t
 
 from unzer.model.base import JSONValue
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/paylater_direct_debit.py
+++ b/src/unzer/model/payment_type/paylater_direct_debit.py
@@ -21,10 +21,10 @@ class PaylaterDirectDebit(PaymentType):
 
     def __init__(
             self,
-            key: str = None,
-            iban: str = None,
-            holder: str = None,
-            country: str = None,
+            key: str | None = None,
+            iban: str | None = None,
+            holder: str | None = None,
+            country: str | None = None,
             **kwargs,
     ):
         """Create a new Paylater Direct Debit paymentType resource.

--- a/src/unzer/model/payment_type/paylater_installment.py
+++ b/src/unzer/model/payment_type/paylater_installment.py
@@ -28,12 +28,12 @@ class PaylaterInstallment(PaymentType):
 
     def __init__(
             self,
-            key: str = None,
-            inquiryId: str = None,
-            numberOfRates: int = None,
-            iban: str = None,
-            country: str = None,
-            holder: str = None,
+            key: str | None = None,
+            inquiryId: str | None = None,
+            numberOfRates: int | None = None,
+            iban: str | None = None,
+            country: str | None = None,
+            holder: str | None = None,
             **kwargs,
     ):
         """Create a new Paylater Installment paymentType resource.

--- a/src/unzer/model/payment_type/paylater_installment.py
+++ b/src/unzer/model/payment_type/paylater_installment.py
@@ -24,7 +24,7 @@ class PaylaterInstallment(PaymentType):
 
     # The API reference marks only inquiryId and numberOfRates as required,
     # while the documentation claims country to be required too
-    REQUIRED_ATTRIBUTES = ["inquiryId", "numberOfRates"]
+    REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = ["inquiryId", "numberOfRates"]
 
     def __init__(
             self,

--- a/src/unzer/model/payment_type/paylater_installment.py
+++ b/src/unzer/model/payment_type/paylater_installment.py
@@ -2,6 +2,7 @@ import typing as t
 
 from unzer.model.base import JSONValue
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/paylater_invoice.py
+++ b/src/unzer/model/payment_type/paylater_invoice.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/paypal.py
+++ b/src/unzer/model/payment_type/paypal.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/payu.py
+++ b/src/unzer/model/payment_type/payu.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/postfinance_card.py
+++ b/src/unzer/model/payment_type/postfinance_card.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/postfinance_efinance.py
+++ b/src/unzer/model/payment_type/postfinance_efinance.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/prepayment.py
+++ b/src/unzer/model/payment_type/prepayment.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/przelewy24.py
+++ b/src/unzer/model/payment_type/przelewy24.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/sepa_direct_debit.py
+++ b/src/unzer/model/payment_type/sepa_direct_debit.py
@@ -22,10 +22,10 @@ class SepaDirectDebit(PaymentType):
 
     def __init__(
             self,
-            key: str = None,
-            iban: str = None,
-            bic: str = None,
-            holder: str = None,
+            key: str | None = None,
+            iban: str | None = None,
+            bic: str | None = None,
+            holder: str | None = None,
             **kwargs,
     ):
         """Create a new SEPA Direct Debit paymentType resource.

--- a/src/unzer/model/payment_type/sepa_direct_debit.py
+++ b/src/unzer/model/payment_type/sepa_direct_debit.py
@@ -2,6 +2,7 @@ import typing as t
 
 from unzer.model.base import JSONValue
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/sepa_direct_debit.py
+++ b/src/unzer/model/payment_type/sepa_direct_debit.py
@@ -18,7 +18,7 @@ class SepaDirectDebit(PaymentType):
 
     # The API reference marks no field as required, but the PHP SDK
     # takes the iban as the only mandatory constructor argument
-    REQUIRED_ATTRIBUTES = ["iban"]
+    REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = ["iban"]
 
     def __init__(
             self,

--- a/src/unzer/model/payment_type/sofort.py
+++ b/src/unzer/model/payment_type/sofort.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/twint.py
+++ b/src/unzer/model/payment_type/twint.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/wechatpay.py
+++ b/src/unzer/model/payment_type/wechatpay.py
@@ -1,4 +1,5 @@
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/payment_type/wero.py
+++ b/src/unzer/model/payment_type/wero.py
@@ -17,8 +17,8 @@ class Wero(PaymentType):
 
     def __init__(
             self,
-            key: str = None,
-            walletId: str = None,
+            key: str | None = None,
+            walletId: str | None = None,
             **kwargs,
     ):
         """Create a new Wero paymentType resource.

--- a/src/unzer/model/payment_type/wero.py
+++ b/src/unzer/model/payment_type/wero.py
@@ -2,6 +2,7 @@ import typing as t
 
 from unzer.model.base import JSONValue
 from unzer.model.payment import PaymentMethodTypes, PaymentTypes
+
 from .abstract_paymenttype import PaymentType
 
 

--- a/src/unzer/model/paymentpage.py
+++ b/src/unzer/model/paymentpage.py
@@ -1,3 +1,4 @@
+import typing as t
 from types import NoneType
 
 from ..utils import parseBool, roundAmount
@@ -6,7 +7,7 @@ from .payment import Action
 
 
 class PaymentPage(BaseModel):
-    REQUIRED_ATTRIBUTES = [
+    REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = [
         "action",
         "amount",
         "currency",
@@ -141,7 +142,7 @@ class PaymentPage(BaseModel):
         self.basketId = basketId  # type:str
 
     def serialize(self):
-        data = {
+        return {
             "amount": roundAmount(self.amount),
             "currency": self.currency,
             "invoiceId": self.invoiceId,
@@ -167,7 +168,6 @@ class PaymentPage(BaseModel):
                 "metadataId": self.metadataId,
             },
         }
-        return data
 
     @classmethod
     def fromDict(cls, data):

--- a/src/unzer/model/paymentpage.py
+++ b/src/unzer/model/paymentpage.py
@@ -1,8 +1,8 @@
 from types import NoneType
 
+from ..utils import parseBool, roundAmount
 from .base import BaseModel
 from .payment import Action
-from ..utils import parseBool, roundAmount
 
 
 class PaymentPage(BaseModel):

--- a/src/unzer/model/risk_check.py
+++ b/src/unzer/model/risk_check.py
@@ -13,13 +13,13 @@ class RiskCheckResponse(BaseModel):
 
     def __init__(
             self,
-            key: str = None,
-            url: str = None,
-            timestamp: datetime.datetime = None,
-            isSuccess: bool = None,
-            isPending: bool = None,
-            isResumed: bool = None,
-            isError: bool = None,
+            key: str | None = None,
+            url: str | None = None,
+            timestamp: datetime.datetime | None = None,
+            isSuccess: bool | None = None,
+            isPending: bool | None = None,
+            isResumed: bool | None = None,
+            isError: bool | None = None,
             **kwargs,
     ):
         """Create a new RiskCheckResponse.

--- a/src/unzer/model/risk_check.py
+++ b/src/unzer/model/risk_check.py
@@ -1,8 +1,8 @@
 import datetime
 import typing as t
 
-from .base import BaseModel, JSONValue
 from ..utils import parseBool, parseDateTime
+from .base import BaseModel, JSONValue
 
 
 class RiskCheckResponse(BaseModel):

--- a/src/unzer/model/webhook.py
+++ b/src/unzer/model/webhook.py
@@ -1,4 +1,5 @@
 import enum
+import typing as t
 
 from .base import BaseModel
 
@@ -66,7 +67,7 @@ class Events(enum.StrEnum):
 
 
 class Webhook(BaseModel):
-    REQUIRED_ATTRIBUTES = [
+    REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = [
         "event",
         "url"
     ]
@@ -101,7 +102,7 @@ class Webhook(BaseModel):
         if isinstance(value, str):
             value = [value]
         if not isinstance(value, list):
-            raise TypeError("Event must be a str or list of str. Got %r" % type(value))
+            raise TypeError(f"Event must be a str or list of str. Got {type(value)!r}")
         events = []
         for val in value:
             try:

--- a/src/unzer/utils.py
+++ b/src/unzer/utils.py
@@ -12,7 +12,7 @@ def parseDateTime(value):
         return value
     if "-" in value:  # ISO Date
         return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
-    elif "." in value:  # European Date
+    if "." in value:  # European Date
         return datetime.datetime.strptime(value, "%d.%m.%Y %H:%M:%S")
     raise TypeError("Invalid date format of %r" % value)
 

--- a/src/unzer/utils.py
+++ b/src/unzer/utils.py
@@ -14,7 +14,7 @@ def parseDateTime(value):
         return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
     if "." in value:  # European Date
         return datetime.datetime.strptime(value, "%d.%m.%Y %H:%M:%S")
-    raise TypeError("Invalid date format of %r" % value)
+    raise TypeError(f"Invalid date format of {value!r}")
 
 
 def parseDate(value):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,5 @@
 """Tests for the transport layer of :class:`unzer.UnzerClient`."""
 
-import json
 
 import pytest
 import requests

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -58,7 +58,7 @@ class TestPaymentTypes:
         assert issubclass(cls, PaymentType)
         # The placeholder must not hand a bogus slug to the request builder.
         with pytest.raises(NotImplementedError):
-            cls.method_name.value
+            _ = cls.method_name.value
 
 
 class TestBasket:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -431,6 +431,7 @@ class TestAmountRounding:
         """12.3 - 10.0 - 2.3 is 8.88e-16, and json.dumps writes that in scientific
         notation -- which is not a number this API accepts."""
         import json
+
         from unzer.model import SepaDirectDebit
         residue = 12.3 - 10.0 - 2.3
         assert residue != 0, "precondition: this is the IEEE-754 residue"
@@ -486,6 +487,7 @@ class TestInstallmentPlansTimestamp:
 
     def test_milliseconds_are_parsed(self, fixture_json):
         import datetime
+
         from unzer.model import InstallmentPlans
         plans = InstallmentPlans.fromDict(fixture_json("installment_plans"))
         assert plans.expiresAt == datetime.datetime.fromtimestamp(1787349029.678)
@@ -493,6 +495,7 @@ class TestInstallmentPlansTimestamp:
     def test_seconds_are_still_parsed(self, fixture_json):
         """The reference shows seconds, so both units have to work."""
         import datetime
+
         from unzer.model import InstallmentPlans
         data = fixture_json("installment_plans") | {"expiresAt": "1735689599"}
         assert InstallmentPlans.fromDict(data).expiresAt == \
@@ -508,6 +511,7 @@ class TestInstallmentPlansTimestamp:
     ])
     def test_parse_timestamp_handles_both_units(self, value, seconds):
         import datetime
+
         from unzer.utils import parseTimestamp
         assert parseTimestamp(value) == datetime.datetime.fromtimestamp(seconds)
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -248,6 +248,17 @@ class TestKeypairWithSeveralConfigurations:
         from unzer.model import Eps
         assert Eps(client=client).get_configuration()["type"] == "EPS"
 
+    def test_missing_client_raises_runtime_error(self):
+        """A payment type built without a client cannot read its configuration.
+
+        That is a programming error, not an I/O problem — it used to raise
+        `IOError`, which ruff normalised to its alias `OSError` before this became
+        a `RuntimeError`.
+        """
+        from unzer.model import Card
+        with pytest.raises(RuntimeError, match="without a client"):
+            Card().get_configuration()
+
     @responses.activate
     def test_unconfigured_type_raises_lookup_error(self, client):
         responses.add(responses.GET, f"{BASE}/keypair/types", json={"paymentTypes": []})

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -142,7 +142,7 @@ class TestUnknownPaymentTypePlaceholder:
         with AttributeError: 'str' object has no attribute 'value'."""
         cls = PaymentType.construct(PaymentTypes.GIROPAY)
         with pytest.raises(NotImplementedError, match="no implementation"):
-            cls.method_name.value
+            _ = cls.method_name.value
 
     def test_placeholder_class_has_a_usable_name(self):
         """Was "Paymenttypes.Giropay"."""


### PR DESCRIPTION
Closes #3.

pycodestyle reported a clean tree while **200 issues** sat in it, because it only checks
formatting. It also silently accepted an invalid `# noqa` directive — the one on the
circular-import workaround, where the text after the colon is prose instead of error codes — and
suppressed every check in that file along with it, including six over-long lines.

ruff is configured in `pyproject.toml` and runs in CI over the full tree. All 200 findings are
resolved without suppressing a single real rule.

**The deviations are named, not hidden.** The naming rules stay off because the public API
mirrors the camelCase of the Unzer payload until 2.0; the star-import rules for `client.py`;
RUF002, because the em dashes in the docstrings are deliberate; RUF022, because `__all__` is
grouped by module rather than sorted.

### Implicit Optional (#3)

71 signatures said `x: str = None` — a `str` that defaults to something which is not one. PEP 484
dropped that reading in 2018 and a strict type checker rejects it, which is part of why the
annotations here were never usable. No runtime change: the parameters were always optional, the
annotation just did not say so. ruff enforces it from here on.

### f-strings, including in logging

`%` formatting is gone. The lazy `%` arguments of `logging` do save the formatting when the level
discards it — measured at ~20 µs for a large payload — but next to an API request whose timeout is
30 seconds that is four orders of magnitude out, and in a ViUR context it does not apply at all
because viur-core puts the root logger on DEBUG.

### Everything else ruff found

`REQUIRED_ATTRIBUTES` is a `ClassVar` instead of a bare mutable class attribute · six
`data = {...}; return data` return directly · `data.get()` instead of `if key in dict` blocks ·
`yield from` · `super()` without arguments · `type[]` for `t.Type[]` · `OSError` for `IOError` ·
an `__all__` in `src/unzer/__init__.py`, so the re-export is explicit rather than an apparently
unused import.

278 unit tests and 19 sandbox tests green, `ruff check` clean, pycodestyle clean.

Docstrings are a separate change, in the PR that follows this one.