### PR TITLE
docs: Document every class and fix the docstrings that were wrong

### DIFF
--- a/src/unzer/__init__.py
+++ b/src/unzer/__init__.py
@@ -1,3 +1,12 @@
+"""An unofficial Python SDK for the Unzer payment API.
+
+Start at :class:`unzer.UnzerClient`; the resource models live in
+:mod:`unzer.model` and are re-exported here.
+
+Unzer's documentation and its official SDKs are both wrong often enough that
+neither can be treated as authoritative -- where this SDK deviates from them,
+the docstring says so and why.
+"""
 __title__ = "unzer-sdk"
 __author__ = "Sven Eberth"
 __email__ = "se@mausbrand.de"

--- a/src/unzer/client.py
+++ b/src/unzer/client.py
@@ -1,3 +1,4 @@
+"""The HTTP client and every API call this SDK supports."""
 import logging
 import time
 import typing as t
@@ -22,6 +23,19 @@ HttpMethod = t.Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
 
 
 class UnzerClient:
+    """Client for the Unzer payment API.
+
+    One instance per keypair. The methods map closely onto the API's resources,
+    so a name here can be traced back to the API reference without a translation
+    table -- which is why they are camelCase.
+
+    Requests are performed synchronously with :mod:`requests`. Errors from the API
+    raise :exc:`~unzer.model.ErrorResponse`; failures below HTTP raise the
+    exceptions of :mod:`requests` itself.
+
+    .. seealso:: https://docs.unzer.com/server-side-integration/api-basics/
+    """
+
     endpoint = "https://api.unzer.com"
     """Base URL of the API, without the version segment."""
 
@@ -296,6 +310,17 @@ class UnzerClient:
         return self.getCustomer(data["id"])
 
     def createOrUpdateCustomer(self, customer):
+        """Create the customer, or update the existing one with the same id.
+
+        Convenience for the common case where it does not matter which of the two
+        it is. Relies on the API answering ``API.410.200.010`` for a ``customerId``
+        that is already taken, and falls back to :meth:`updateCustomer` then.
+
+        :param customer: Customer object, with ``customerId`` set.
+        :type customer: Customer
+        :return: The created or updated customer.
+        :rtype: Customer
+        """
         try:
             return self.createCustomer(customer)
         except ErrorResponse as er:

--- a/src/unzer/model/additional_transaction_data.py
+++ b/src/unzer/model/additional_transaction_data.py
@@ -10,6 +10,13 @@ logger = logging.getLogger("unzer-sdk").getChild(__name__)
 
 
 class CardTransactionData(BaseModel):
+    """Card-specific transaction data.
+
+    :attr:`recurrenceType` marks a payment as part of a series, which affects both
+    the fees and where the liability sits. :attr:`exemptionType` asks for an
+    exemption from strong customer authentication.
+    """
+
     def __init__(
             self,
             recurrenceType: t.Literal["scheduled", "unscheduled", "oneclick"] | None = None,
@@ -48,6 +55,8 @@ class CardTransactionData(BaseModel):
 
 
 class ShippingTransactionData(BaseModel):
+    """Shipping details, used by the Pay later methods for their risk checks."""
+
     def __init__(
             self,
             deliveryTrackingId: str | None = None,
@@ -105,6 +114,13 @@ class RegistrationLevel(enum.IntEnum):
 
 
 class RiskData(BaseModel):
+    """What the merchant knows about the customer, for Unzer's fraud checks.
+
+    All optional, and all of it improves the acceptance rate of the Pay later
+    methods: how long the customer has had an account, how many orders they have
+    completed, which risk group they are in.
+    """
+
     def __init__(
             self,
             confirmedAmount: float | None = None,
@@ -154,6 +170,8 @@ class RiskData(BaseModel):
 
 
 class PaypalData(BaseModel):
+    """PayPal-specific transaction data."""
+
     def __init__(
             self,
             checkoutType: t.Literal["EXPRESS"] | None = None,
@@ -179,6 +197,17 @@ class PaypalData(BaseModel):
 
 
 class AdditionalTransactionData(BaseModel):
+    """Extra data sent alongside a payment.
+
+    Optional for most methods and required for some: card payments need it for
+    recurrence and exemption handling, and the risk data feeds Unzer's fraud
+    checks. Request-only -- the API returns these fields in a shape this model
+    does not read back.
+
+    The API knows more sub-objects than this covers (``paylater``,
+    ``onlineTransfer``, and the terms and privacy URLs some methods require).
+    """
+
     def __init__(
             self,
             card: CardTransactionData = None,

--- a/src/unzer/model/address.py
+++ b/src/unzer/model/address.py
@@ -2,6 +2,13 @@ from .base import BaseModel
 
 
 class Address(BaseModel):
+    """A billing or shipping address.
+
+    The wire format has a single ``name`` field, which this model splits into
+    :attr:`firstname` and :attr:`lastname` and joins again on serialisation. Note
+    that it calls the postcode ``zip``, while the attribute is :attr:`zipCode`.
+    """
+
     def __init__(
             self,
             firstname,
@@ -15,9 +22,10 @@ class Address(BaseModel):
     ):
         """Create a new Address.
 
-        :param firstname: (optional) Address firstname (+lastname: max. 81 chars). Required in case of billing address.
+        :param firstname: Address first name. Together with the last name at most
+            81 characters, because the wire format joins them into one ``name``.
         :type firstname: str
-        :param lastname: (optional)  Address lastname (+firstname: max. 81 chars). Required in case of billing address.
+        :param lastname: Address last name, see above.
         :type lastname: str
         :param street: (optional) Address street (max. 50 chars). Required in case of billing address.
         :type street: str
@@ -40,11 +48,17 @@ class Address(BaseModel):
         self.country = country  # type: str
 
     @property
-    def name(self):
+    def name(self) -> str:
+        """First and last name joined, which is how the API expects an address."""
         return f"{self.getString(self.firstname)} {self.getString(self.lastname)}"
 
     @name.setter
-    def name(self, name):
+    def name(self, name: str) -> None:
+        """Split a name on the first space; everything after it is the last name.
+
+        A name without a space becomes the first name and leaves the last name
+        unset, which is the best that can be done without guessing.
+        """
         try:
             self.firstname, self.lastname = name.split(" ", 1)
         except ValueError:

--- a/src/unzer/model/base.py
+++ b/src/unzer/model/base.py
@@ -1,3 +1,4 @@
+"""The base class every resource model derives from."""
 import abc
 import typing as t
 
@@ -8,6 +9,20 @@ JSONValue: t.TypeAlias = str | int | float | bool | list["JSONValue"] | dict[str
 
 
 class BaseModel(abc.ABC):
+    """Base class for every resource model.
+
+    A model is a plain Python object mirroring one API resource. It converts in
+    both directions: :meth:`serialize` builds the request payload,
+    :meth:`fromDict` reads a response. Response-only models raise
+    :exc:`NotImplementedError` from :meth:`serialize`, and request-only models do
+    the same from :meth:`fromDict`.
+
+    Subclasses list the attributes the API insists on in
+    :attr:`REQUIRED_ATTRIBUTES`, which :meth:`validateBeforeRequest` checks before
+    a request goes out -- catching a missing field here saves a round trip and
+    gives a clearer error than the API's.
+    """
+
     EMPTY_STRING = ""
 
     REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = []
@@ -23,7 +38,13 @@ class BaseModel(abc.ABC):
         super().__init__()
         self._client: UnzerClient = client
 
-    def getString(self, value):
+    def getString(self, value: object) -> object:
+        """Turn ``None`` into an empty string for fields the API wants as text.
+
+        Only for string fields: an object field rejects an empty string. Sending
+        ``billingAddress: ""`` for a missing address made the API answer
+        ``400 API.410.300.007``.
+        """
         if value is None:
             return self.EMPTY_STRING
         return value

--- a/src/unzer/model/basketItem.py
+++ b/src/unzer/model/basketItem.py
@@ -5,6 +5,13 @@ from .base import BaseModel, JSONValue
 
 
 class BasketItem(BaseModel):
+    """A single line item of a :class:`~unzer.model.Basket`.
+
+    Follows the same two schemas as the basket around it, and on its own: the
+    field set decides which one, so do not mix them within one basket. See
+    :class:`~unzer.model.Basket`.
+    """
+
     def __init__(
             self,
             basketItemReferenceId=None,

--- a/src/unzer/model/customer.py
+++ b/src/unzer/model/customer.py
@@ -19,6 +19,15 @@ class Salutation:
 
 
 class Customer(BaseModel):
+    """A customer resource.
+
+    Identified either by the resource id assigned by Unzer (:attr:`key`) or by an
+    id of your own (:attr:`customerId`), which has to be unique per keypair.
+    :attr:`keyOrCustomerId` returns whichever is set.
+
+    The Pay later payment methods require a customer with a billing address and a
+    date of birth for their credit check.
+    """
 
     def __init__(
             self,
@@ -41,9 +50,9 @@ class Customer(BaseModel):
 
         :param key: (optional) (original: id) Customer's generated code by Unzer's Payment
         :type key: str
-        :param firstname: Customer's lastname
+        :param firstname: Customer's first name
         :type firstname: str
-        :param lastname: Customer's firstname
+        :param lastname: Customer's last name
         :type lastname: str
         :param salutation: (optional) Must be either 'mr', 'mrs' or 'unknown'
         :type salutation: str | Salutation
@@ -87,15 +96,28 @@ class Customer(BaseModel):
         self.companyData = companyData  # type: CompanyInfo
 
     @property
-    def keyOrCustomerId(self):
+    def keyOrCustomerId(self) -> str | None:
+        """The id to address this customer by, preferring the one Unzer assigned.
+
+        Both work in the URL of a customer resource: the resource id from Unzer
+        and the merchant's own ``customerId``.
+        """
         return self.key or self.customerId
 
     @property
-    def salutation(self):
+    def salutation(self) -> str:
+        """Salutation of the customer, one of ``mr``, ``mrs`` or ``unknown``."""
         return self._salutation
 
     @salutation.setter
-    def salutation(self, value):
+    def salutation(self, value: str | None) -> None:
+        """Set the salutation, defaulting an empty value to ``unknown``.
+
+        ``unknown`` is a real value of the API, not a placeholder -- it says no
+        salutation is known for this customer.
+
+        :raises TypeError: For anything but ``mr``, ``mrs`` and ``unknown``.
+        """
         if not value:
             value = Salutation.UNKNOWN
         elif value not in {Salutation.MR, Salutation.MRS, Salutation.UNKNOWN}:
@@ -103,11 +125,20 @@ class Customer(BaseModel):
         self._salutation = value
 
     @property
-    def birthDate(self):
+    def birthDate(self) -> "datetime.datetime | datetime.date | None":
+        """Date of birth, required by the Pay later methods for their credit check."""
         return self._birthDate
 
     @birthDate.setter
-    def birthDate(self, value):
+    def birthDate(self, value: str | datetime.date | datetime.datetime | None) -> None:
+        """Set the date of birth, accepting both formats the API documents.
+
+        ``1990-01-24`` and ``24.01.1990`` are both parsed; a
+        :class:`~datetime.date` or :class:`~datetime.datetime` is taken as is.
+        Serialisation always writes the ISO form.
+
+        :raises TypeError: For a string in neither format, or an unusable type.
+        """
         if not value:
             value = None
         elif isinstance(value, str):
@@ -122,21 +153,23 @@ class Customer(BaseModel):
         self._birthDate = value
 
     @property
-    def phone(self):
+    def phone(self) -> str | None:
+        """Landline number. An empty value is normalised to ``None``."""
         return self._phone
 
     @phone.setter
-    def phone(self, value):
+    def phone(self, value: str | None) -> None:
         if not value:
             value = None
         self._phone = value
 
     @property
-    def mobile(self):
+    def mobile(self) -> str | None:
+        """Mobile number. An empty value is normalised to ``None``."""
         return self._mobile
 
     @mobile.setter
-    def mobile(self, value):
+    def mobile(self, value: str | None) -> None:
         if not value:
             value = None
         self._mobile = value

--- a/src/unzer/model/error.py
+++ b/src/unzer/model/error.py
@@ -5,6 +5,15 @@ logger = logging.getLogger("unzer-sdk").getChild(__name__)
 
 
 class Error:
+    """A single error entry of an API response.
+
+    The API answers with a list of these. :attr:`merchantMessage` is the one worth
+    logging; :attr:`customerMessage` is meant to be shown to the customer and is
+    translated according to the language the client was built with.
+
+    .. seealso:: https://docs.unzer.com/server-side-integration/api-basics/error-handling/
+    """
+
     def __init__(self, code, merchantMessage, customerMessage, **kwargs):
         self.code = code
         self.merchantMessage = merchantMessage
@@ -24,6 +33,17 @@ class Error:
 
 
 class ErrorResponse(Exception):
+    """Raised when the API reports an error.
+
+    Carries the whole payload: the individual :attr:`errors`, the
+    :attr:`errorId` (``s-err-...``, which Unzer support can resolve), the
+    :attr:`traceId` and the HTTP :attr:`statusCode`. :attr:`srcResponse` holds the
+    raw :class:`requests.Response`.
+
+    Note that the API can report an error **with a 2xx status code** -- a payload
+    carrying ``isError`` raises just the same.
+    """
+
     def __init__(
             self,
             message,

--- a/src/unzer/model/payment.py
+++ b/src/unzer/model/payment.py
@@ -1,3 +1,9 @@
+"""Payments, their transactions, and the enums describing both.
+
+A payment is the umbrella over one order: its state, its amounts, and the list of
+transactions it accumulated. Note that the list contains every transaction the
+payment has, including kinds this SDK cannot create.
+"""
 import enum
 import logging
 import re
@@ -181,6 +187,19 @@ paymentUrlRe = re.compile(
 
 
 class PaymentGetResponse(BaseModel):
+    """A payment, as returned by :meth:`~unzer.UnzerClient.getPayment`.
+
+    The payment is the umbrella over everything that happened to one order: its
+    :attr:`state`, the amounts, the ids of the resources involved, and every
+    :class:`PaymentTransaction` it holds. That list is the reason
+    :class:`Action` has to know transaction types this SDK cannot create -- a
+    payment that was cancelled elsewhere still reads back here.
+
+    :attr:`amountTotal` is the authorised amount minus cancellations,
+    :attr:`amountCharged` what was actually captured, and
+    :attr:`amountRemaining` the difference. Treat anything but
+    :attr:`~PaymentState.COMPLETED` as not paid.
+    """
 
     def __init__(
             self,
@@ -345,6 +364,16 @@ class PaymentGetResponse(BaseModel):
             ) from None
 
     def charge(self, amount: float) -> "PaymentResponse":
+        """Capture an amount on this payment.
+
+        For payment methods that are authorised first and captured later -- Klarna
+        and the Pay later methods, typically on shipment. Requires the model to
+        have been read through a client, since it performs a request of its own.
+
+        :param amount: The amount to capture. Can be less than the authorised
+            amount; the rest stays open.
+        :return: The transaction that was created.
+        """
         req_kwargs = self.__dict__.copy()
         req_kwargs["paymentType"] = PaymentType.construct(self.paymentType)(self.typeId)
         req_kwargs["amount"] = amount
@@ -353,6 +382,14 @@ class PaymentGetResponse(BaseModel):
 
 
 class PaymentTransaction(BaseModel):
+    """One transaction within a payment.
+
+    :attr:`action` says what kind it is and :attr:`status` how it went. The ids
+    are parsed out of the transaction's URL, because the API does not return them
+    as separate fields -- which is why :attr:`url` is required for this model to
+    be readable at all.
+    """
+
     def __init__(
             self,
             paymentId=None,
@@ -428,6 +465,17 @@ class PaymentTransaction(BaseModel):
 
 
 class PaymentRequest(BaseModel):
+    """The payload of an authorize or charge call.
+
+    Request-only; use :class:`PaymentResponse` for what comes back. The payment
+    type is the one required field -- if it has no ``key`` yet, the client creates
+    it as part of the call.
+
+    :attr:`returnUrl` is required for every payment method that sends the customer
+    away, which is most of them, and for the Pay later methods it is required
+    outright because their verification flow redirects.
+    """
+
     REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = ["paymentType"]
 
     def __init__(
@@ -532,6 +580,17 @@ class PaymentRequest(BaseModel):
 
 
 class PaymentResponse(BaseModel):
+    """The result of an authorize or charge call.
+
+    Three flags, of which exactly one is set: :attr:`isSuccess`,
+    :attr:`isPending`, :attr:`isError`. Pending is not a failure -- it means the
+    customer has to confirm something at :attr:`redirectUrl`, after which the
+    outcome has to be fetched with :meth:`~unzer.UnzerClient.getPayment`.
+
+    :attr:`processing` carries the reference numbers to quote in support cases,
+    and for prepayment or invoice the bank details the customer has to transfer to.
+    """
+
     def __init__(
             self,
             transactionId=None,
@@ -680,6 +739,14 @@ class PaymentResponse(BaseModel):
         return cls(**data, client=client)
 
     def charge(self, amount: float) -> "PaymentResponse":
+        """Capture an amount on the payment this response belongs to.
+
+        Same as :meth:`PaymentGetResponse.charge`, so that a capture can follow
+        straight on from an authorization without fetching the payment first.
+
+        :param amount: The amount to capture.
+        :return: The transaction that was created.
+        """
         req_kwargs = self.__dict__.copy()
         paymentTypeName = PaymentGetResponse.getPaymentTypeFromTypeId(self.typeId)
         req_kwargs["paymentType"] = PaymentType.construct(paymentTypeName)(self.typeId)
@@ -689,6 +756,17 @@ class PaymentResponse(BaseModel):
 
 
 class PaymentResponseMetadata(BaseModel):
+    """The ``processing`` block of a payment response.
+
+    Which of these fields are filled depends entirely on the payment method:
+    :attr:`uniqueId`, :attr:`shortId` and :attr:`traceId` are always there, the
+    bank details only for the methods that need them, and they can be missing
+    while a verification is still outstanding.
+
+    :attr:`shortId` is the reference a customer can read out over the phone;
+    :attr:`traceId` is the one Unzer support asks for.
+    """
+
     def __init__(
             self,
             creatorId=None,

--- a/src/unzer/model/payment_type/__init__.py
+++ b/src/unzer/model/payment_type/__init__.py
@@ -1,3 +1,9 @@
+"""One class per payment method.
+
+Seven of them take data from the server, the rest are created in the browser and
+deliberately carry no fields. Which is which, and why, is in
+``docs/payment-methods.md``.
+"""
 from .abstract_paymenttype import PaymentType
 from .alipay import Alipay
 from .applepay import Applepay

--- a/src/unzer/model/payment_type/abstract_paymenttype.py
+++ b/src/unzer/model/payment_type/abstract_paymenttype.py
@@ -20,6 +20,7 @@ class _UnknownMethodName:
 
     @property
     def value(self) -> str:
+        """Always raises: an unimplemented payment type has no resource path."""
         raise NotImplementedError(
             "This payment type has no implementation in this SDK, so its resource "
             "path is unknown. It can be used to read existing payments, but not to "
@@ -31,6 +32,20 @@ class _UnknownMethodName:
 
 
 class PaymentType(BaseModel):
+    """Base class of every payment method.
+
+    A payment type is a resource at Unzer, and its id (``s-crd-...``) is what a
+    payment refers to. Two names identify the method, and they differ:
+    :attr:`method` is the three-letter short code inside that id, while
+    :attr:`method_name` is the slug in the ``types/`` path.
+
+    Which of the two ways a type comes into being decides whether its subclass
+    carries fields at all -- server-side for seven of them, in the browser for the
+    rest, whose classes are deliberately empty.
+
+    .. seealso:: ../../../docs/payment-methods.md
+    """
+
     @property
     @abc.abstractmethod
     def method(self) -> "PaymentTypes":
@@ -66,12 +81,23 @@ class PaymentType(BaseModel):
 
     @classmethod
     def get_subclasses(cls) -> t.Iterator[type[t.Self]]:
+        """Yield every payment type class, including those of subclasses."""
         for subclass in cls.__subclasses__():
             yield from subclass.get_subclasses()
             yield subclass
 
     @classmethod
     def construct(cls, method: "PaymentTypes") -> type["PaymentType"]:
+        """Find the class implementing a payment method.
+
+        For a method this SDK does not implement -- a discontinued or deprecated
+        one -- a placeholder class is built, so that existing payments still read
+        back. That placeholder cannot create a new payment type: asking it for its
+        resource path raises.
+
+        :param method: The short code of the method, as it appears in a type id.
+        :return: The class, not an instance.
+        """
         for subclass in PaymentType.get_subclasses():
             if subclass.method == method:
                 return subclass
@@ -86,12 +112,15 @@ class PaymentType(BaseModel):
         return sub_cls  # noqa
 
     def get_configuration(self) -> dict:
-        if self._client is None:
-            raise RuntimeError(
-                f"{type(self).__name__} was created without a client, so it cannot "
-                f"read its keypair configuration. Pass client= to the constructor, "
-                f"or use the instance the client returned."
-            )
+        """Provide the keypair configuration for this payment type.
+
+        Returns the first entry when the keypair holds several, which it can --
+        see :meth:`get_configurations`. Prefer passing a brand to
+        :meth:`get_channel_id` over relying on the order here.
+
+        :raises LookupError: If the payment type is not configured at all.
+        :raises RuntimeError: If this payment type was created without a client.
+        """
         configurations = self.get_configurations()
         if len(configurations) > 1:
             logger.warning(

--- a/src/unzer/model/payment_type/applepay.py
+++ b/src/unzer/model/payment_type/applepay.py
@@ -4,5 +4,14 @@ from .abstract_paymenttype import PaymentType
 
 
 class Applepay(PaymentType):
+    """Apple Pay.
+
+    The payload is a signed token only the wallet can produce. Created in the browser
+    through the payment page or the UI components, so this class carries no fields -- the
+    backend only receives the resulting type id.
+
+    .. seealso:: ``docs/payment-methods.md``
+    """
+
     method = PaymentTypes.APPLE_PAY
     method_name = PaymentMethodTypes.APPLE_PAY

--- a/src/unzer/model/payment_type/bancontact.py
+++ b/src/unzer/model/payment_type/bancontact.py
@@ -6,6 +6,14 @@ from .abstract_paymenttype import PaymentType
 
 
 class Bancontact(PaymentType):
+    """Bancontact.
+
+    Takes an optional card holder; everything else the customer enters at the
+    redirect.
+
+    .. seealso:: ``docs/payment-methods.md``
+    """
+
     method = PaymentTypes.BANCONTACT
     method_name = PaymentMethodTypes.BANCONTACT
 

--- a/src/unzer/model/payment_type/card.py
+++ b/src/unzer/model/payment_type/card.py
@@ -4,5 +4,14 @@ from .abstract_paymenttype import PaymentType
 
 
 class Card(PaymentType):
+    """Credit or debit card.
+
+    Deliberately without card fields: accepting raw card data would put the integration
+    under PCI-DSS obligations. Created in the browser through the payment page or the UI
+    components, so the backend only receives the resulting type id.
+
+    .. seealso:: ``docs/payment-methods.md``
+    """
+
     method = PaymentTypes.CARD
     method_name = PaymentMethodTypes.CARD

--- a/src/unzer/model/payment_type/googlepay.py
+++ b/src/unzer/model/payment_type/googlepay.py
@@ -4,5 +4,14 @@ from .abstract_paymenttype import PaymentType
 
 
 class Googlepay(PaymentType):
+    """Google Pay.
+
+    The payload is a signed token only the browser can produce. Created in the browser
+    through the payment page or the UI components, so this class carries no fields -- the
+    backend only receives the resulting type id.
+
+    .. seealso:: ``docs/payment-methods.md``
+    """
+
     method = PaymentTypes.GOOGLE_PAY
     method_name = PaymentMethodTypes.GOOGLE_PAY

--- a/src/unzer/model/payment_type/ideal.py
+++ b/src/unzer/model/payment_type/ideal.py
@@ -4,5 +4,14 @@ from .abstract_paymenttype import PaymentType
 
 
 class Ideal(PaymentType):
+    """iDEAL.
+
+    Created in the browser through the payment page or the UI components,
+    so this class carries no fields -- the backend only receives the resulting
+    type id.
+
+    .. seealso:: ``docs/payment-methods.md``
+    """
+
     method = PaymentTypes.IDEAL
     method_name = PaymentMethodTypes.IDEAL

--- a/src/unzer/model/payment_type/klarna.py
+++ b/src/unzer/model/payment_type/klarna.py
@@ -4,5 +4,14 @@ from .abstract_paymenttype import PaymentType
 
 
 class Klarna(PaymentType):
+    """Klarna.
+
+    Cannot be charged directly: authorise first, then charge once the customer returns from
+    the redirect. Created in the browser through the payment page or the UI components, so
+    this class carries no fields.
+
+    .. seealso:: ``docs/payment-methods.md``
+    """
+
     method = PaymentTypes.KLARNA
     method_name = PaymentMethodTypes.KLARNA

--- a/src/unzer/model/payment_type/paypal.py
+++ b/src/unzer/model/payment_type/paypal.py
@@ -4,5 +4,14 @@ from .abstract_paymenttype import PaymentType
 
 
 class PayPal(PaymentType):
+    """PayPal.
+
+    Created in the browser through the payment page or the UI components,
+    so this class carries no fields -- the backend only receives the resulting
+    type id.
+
+    .. seealso:: ``docs/payment-methods.md``
+    """
+
     method = PaymentTypes.PAYPAL
     method_name = PaymentMethodTypes.PAYPAL

--- a/src/unzer/model/payment_type/sofort.py
+++ b/src/unzer/model/payment_type/sofort.py
@@ -4,5 +4,14 @@ from .abstract_paymenttype import PaymentType
 
 
 class Sofort(PaymentType):
+    """Sofort.
+
+    Being discontinued by Unzer. Created in the browser through the payment page or the UI components,
+    so this class carries no fields -- the backend only receives the resulting
+    type id.
+
+    .. seealso:: ``docs/payment-methods.md``
+    """
+
     method = PaymentTypes.SOFORT
     method_name = PaymentMethodTypes.SOFORT

--- a/src/unzer/model/paymentpage.py
+++ b/src/unzer/model/paymentpage.py
@@ -7,6 +7,20 @@ from .payment import Action
 
 
 class PaymentPage(BaseModel):
+    """A hosted or embedded payment page.
+
+    Unzer hosts the page, the customer picks a payment method there, and no card
+    data reaches your server. The shortest complete flow, and the only one that
+    works for every payment method without a frontend integration of your own.
+
+    :attr:`action` decides whether the payment is charged straight away or only
+    authorised.
+
+    .. note::
+        This is the v1 payment page, which the OpenAPI spec tags as deprecated in
+        favour of a v2 on its own host. v1 still works; v2 is not implemented here.
+    """
+
     REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = [
         "action",
         "amount",
@@ -175,6 +189,13 @@ class PaymentPage(BaseModel):
 
 
 class PaymentPageResponse(PaymentPage):
+    """The payment page as the API returns it.
+
+    Adds the fields only the response has -- most importantly
+    :attr:`redirectUrl`, where the customer has to be sent, and
+    :attr:`paymentId`, which is how the payment is looked up afterwards.
+    """
+
     def __init__(
             self,
             payPageId=None,

--- a/src/unzer/model/webhook.py
+++ b/src/unzer/model/webhook.py
@@ -67,6 +67,19 @@ class Events(enum.StrEnum):
 
 
 class Webhook(BaseModel):
+    """A webhook registration.
+
+    One registration per event: passing several events to :attr:`event` makes the
+    API create one webhook each, which is why the create and list calls return a
+    list. Only the URL of an existing webhook can be changed, never its event.
+
+    Unzer does **not** sign its notifications. Verify them by checking the source
+    address against Unzer's IP allowlist and by fetching the resource from the
+    ``retrieveUrl`` the notification names -- never trust its body.
+
+    .. seealso:: https://docs.unzer.com/server-side-integration/api-basics/notifications/
+    """
+
     REQUIRED_ATTRIBUTES: t.ClassVar[list[str]] = [
         "event",
         "url"
@@ -94,11 +107,19 @@ class Webhook(BaseModel):
         self.url = url
 
     @property
-    def event(self):
+    def event(self) -> list[Events]:
+        """The events this webhook is registered for, always as a list."""
         return self._event
 
     @event.setter
-    def event(self, value):
+    def event(self, value: str | list[str]) -> None:
+        """Set one event or several, always storing a list.
+
+        A single event is wrapped, so the create call can treat both the same way
+        -- the API takes a list and answers with one webhook per event.
+
+        :raises TypeError: If a value is not a known event.
+        """
         if isinstance(value, str):
             value = [value]
         if not isinstance(value, list):

--- a/src/unzer/utils.py
+++ b/src/unzer/utils.py
@@ -1,11 +1,24 @@
+"""Conversions between the wire format and Python types.
+
+The API is inconsistent about how it encodes values -- amounts arrive as
+strings, dates in two different formats, timestamps in a unit its own reference
+gets wrong -- so these helpers exist to keep that out of the models.
+"""
 import datetime
 
 
-def parseBool(value):
+def parseBool(value: object) -> bool:
+    """Read a boolean the API sent as the string ``"true"`` or ``"false"``."""
     return str(value).lower() == "true"
 
 
-def parseDateTime(value):
+def parseDateTime(value: str | datetime.datetime | None) -> datetime.datetime | None:
+    """Parse a timestamp in either of the two formats the API uses.
+
+    ``2026-08-21 10:15:32`` and ``21.08.2026 10:15:32`` are both accepted.
+
+    :raises TypeError: If the string matches neither format.
+    """
     if not value:
         return None
     if isinstance(value, datetime.datetime):


### PR DESCRIPTION
Stacked on #11 — merge that first, GitHub then retargets this to `develop`.

All 60 classes have a docstring now, where 31 did. The ones worth reading are the models that
carry behaviour rather than just fields: what a payment is as opposed to a transaction, that a
pending response is not a failure but a redirect the customer still has to follow, that
`processing` holds different fields per payment method and can be incomplete while a verification
is outstanding.

The payment type classes explain **why they are empty** — created in the browser, so there is
nothing for the server to send — and `Card` says outright that taking card data would put the
integration under PCI-DSS obligations. That question came up twice while working on this SDK, and
the answer belongs where the empty class is.

**Three docstrings were factually wrong:** `Customer` had firstname and lastname swapped in their
descriptions, and `Address` called two positional parameters optional.

Property getters now carry the documentation rather than only their setters, because the getter's
docstring is the one Sphinx renders. And the two public `charge()` methods had none at all, which
for a method that captures money is the wrong place to be terse.

Module docstrings for the six modules where they orient rather than restate the filename.

`serialize`/`fromDict` overrides stay undocumented on purpose: their contract is on `BaseModel`,
and an override that does nothing special has nothing to add. That leaves 60/60 classes and 69 of
126 public functions documented, the gap being those 55 overrides.

One non-doc change came with it, named in the commit: the client check in `get_configuration` was
duplicated in `get_configurations`, and now sits only where the client is actually used.